### PR TITLE
Add Dockerfile for distribution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:20.04
+LABEL maintainer="UNAVCO"
+
+RUN apt-get update && \
+    apt-get install -y gfortran python3-pip unzip wget && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/gnssrefl/exe /etc/gnssrefl/orbits /etc/gnssrefl/refl_code/Files
+
+RUN cd /tmp && \
+    wget https://www.unavco.org/software/data-processing/teqc/development/teqc_CentOSLx86_64d.zip \
+    && unzip teqc_CentOSLx86_64d.zip -d /etc/gnssrefl/exe \
+    && rm teqc*
+
+RUN cd /tmp && \
+    wget https://terras.gsi.go.jp/ja/crx2rnx/RNXCMP_4.0.8_Linux_x86_64bit.tar.gz \
+    && tar -xf RNXCMP_4.0.8_Linux_x86_64bit.tar.gz \
+    && cp RNXCMP_4.0.8_Linux_x86_64bit/bin/CRX2RNX /etc/gnssrefl/exe/ \
+    && rm -rf RNXCMP*
+
+COPY vendor/gfzrnx_1.15-8044_lx64 /etc/gnssrefl/exe/gfzrnx
+
+ENV EXE=/etc/gnssrefl/exe
+ENV ORBITS=/etc/gnssrefl/orbits
+ENV REFL_CODE=/etc/gnssrefl/refl_code
+
+ENV PATH="/etc/gnssrefl/exe:$PATH"
+
+COPY pyproject.toml README.md setup.py /usr/src/gnssrefl/
+COPY gnssrefl /usr/src/gnssrefl/gnssrefl
+RUN pip3 install /usr/src/gnssrefl


### PR DESCRIPTION
This is based on the work of @timdittmann [on UNAVCO's GitLab instance](https://www.unavco.org/gitlab/gnss_reflectometry/gnssrefl_docker/-/blob/master/Dockerfile), with the following changes:

* Use an Ubuntu LTS release rather than rolling release (20.04 instead of 21.04), since LTS versions receive five years of support while rolling versions are EOL'd after only 9 months.
* Put the Dockerfile in the same repository as the code it is bundling, so that we can `COPY` it directly in, rather than cloning it from the network.
* Migrate away from deprecated `MAINTAINER` directive in favor of `LABEL`. (Including a contact email address in this line is generally recommended as well.)
* Add `.dockerignore` to improve build time by omitting unused files from the build context.
* Use standard Python tooling rather than Miniconda.
* Use filesystem paths that respect the [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard), i.e. `/usr/src/gnssrefl` for the source and `/etc/gnssrefl/*` for configuration and data. It might be worth thinking about whether some of these files should instead live in `/usr/sbin`, `/var/cache/gnssrefl`, etc. I'm not familiar with the usage of the directories used by this package so I may not have made the optimal choice locating them all under `/etc/gnssrefl`.
* Vendor the `gfzrnx` binary into the repo. It would be better, however, to download it from elsewhere or compile it using a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/).
