### PR TITLE
Update Dockerfile to account for station_pos, gpt_1a.pkl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ RUN pip3 install --no-cache-dir /usr/src/gnssrefl
 RUN mkdir -p /etc/gnssrefl/refl_code/input/
 RUN cp /usr/src/gnssrefl/gnssrefl/gpt_1wA.pickle /etc/gnssrefl/refl_code/input/
 RUN cp /usr/src/gnssrefl/gnssrefl/station_pos.db /etc/gnssrefl/refl_code/Files/
+WORKDIR /usr/src/gnssrefl


### PR DESCRIPTION
Changed Docker working directory to /gnssrefl to accommodate where gnssir() looks for gpt_1a.pkl and where make_json_input() looks for station_pos.db.

Currently these are copied into a separate locations (ie /refl_code/input/) in the docker build where these functions also look.
`RUN cp /usr/src/gnssrefl/gnssrefl/gpt_1wA.pickle /etc/gnssrefl/refl_code/input/
RUN cp /usr/src/gnssrefl/gnssrefl/station_pos.db /etc/gnssrefl/refl_code/Files/`

However, they were subsequently deleted in the initial docker run volume mount "nocopy" default mode.
`docker run -it -v $(pwd)/refl_code:/etc/gnssrefl/refl_code/ -v $(pwd)/refl_code/Files:/etc/gnssrefl/refl_code/Files --name gnssrefl unavdocker/gnssrefl:latest /bin/bash`

Should modify for more robust solution should the user change paths inside the container, but this is a temporary fix.