### PR TITLE
GitHub container cicd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,32 +3,33 @@ name: ci
 on:
   push:
     branches:
-      - 'master'
+      - 'github_container_cicd'
 
 jobs:
-  docker:
+  build:
+    name: 'Build'
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: "Build:checkout"
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      -
-        name: Build and push
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set environment variables for docker build
+        run: |
+          # Lowercase repo for Github Container Registry
+          echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+      - name: 'Build:dockerimage'
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: unavdocker/gnssrefl:latest
+          tags: ghcr.io/${{ env.REPO }}:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - 'github_container_cicd'
+      - 'master'
 
 jobs:
   build:


### PR DESCRIPTION
Modified github  container workflow to push image to github container registry instead of unavco dockerhub.

This is currently set up to push updated multi-architecture images with each commit to 'master'.
Newest image will be ghcr.io/<gh_name>/gnssrefl:latest using GITHUB_TOKEN.