### PR TITLE
Update docker_cl_instructions.md - Windows

### DIFF
--- a/docs/pages/docker_cl_instructions.md
+++ b/docs/pages/docker_cl_instructions.md
@@ -85,16 +85,16 @@ Docker run commands have slightly different syntax to accomodate windows directo
 Windows Power Shell:
 
 <PRE>
-docker run -it -v ${pwd}\refl_code:/etc/gnssrefl/refl_code/ \
--v ${pwd}\refl_code\Files:/etc/gnssrefl/refl_code/Files \
+docker run -it -v ${pwd}\refl_code:/etc/gnssrefl/refl_code/ `
+-v ${pwd}\refl_code\Files:/etc/gnssrefl/refl_code/Files `
 --name gnssrefl ghcr.io/kristinemlarson/gnssrefl:latest /bin/bash 
 </pre>
 
 Windows Command Line:
 
 <PRE>
-docker run -it -v %cd%\refl_code:/etc/gnssrefl/refl_code/ \
--v %cd%\refl_code\Files:/etc/gnssrefl/refl_code/Files \
+docker run -it -v %cd%\refl_code:/etc/gnssrefl/refl_code/ ^
+-v %cd%\refl_code\Files:/etc/gnssrefl/refl_code/Files ^
 --name gnssrefl ghcr.io/kristinemlarson/gnssrefl:latest /bin/bash 
 </pre>
 


### PR DESCRIPTION
line continuation character is not "\" in Windows: https://superuser.com/questions/1222009/line-break-in-windows-command-prompt https://stackoverflow.com/questions/3235850/how-to-enter-a-multi-line-command