### PR TITLE
Two more options for sub-daily Rinex 3 files

### DIFF
--- a/gnssrefl/rinex2snr_cl.py
+++ b/gnssrefl/rinex2snr_cl.py
@@ -42,6 +42,8 @@ def parse_arguments():
     parser.add_argument("-translator", default=None, help="translator(fortran,hybrid,python)", type=str)
     parser.add_argument("-samplerate", default=None, help="sample rate in sec (RINEX 3 only)", type=int)
     parser.add_argument("-stream", default=None, help="Set to R or S (RINEX 3 only)", type=str)
+    parser.add_argument("-hrmn", default=None, help="Set hour and minute for RINEX 3 file name (sub-daily RINEX 3 only)", type=str)
+    parser.add_argument("-fileperiod", default=None, help="Set file period for RINEX 3 file name (sub-daily RINEX 3 only)", type=str)
     parser.add_argument("-mk", default=None, help="use True for uppercase station names ", type=str)
     parser.add_argument("-weekly", default=None, help="use True for weekly data translation", type=str)
     parser.add_argument("-strip", default=None, help="use True to reduce number of obs", type=str)
@@ -59,7 +61,7 @@ def parse_arguments():
 def rinex2snr(station: str, year: int, doy: int, snr: int = 66, orb: str = 'nav', rate: str = 'low', dec: int = 0,
               fortran: bool = False, nolook: bool = False, archive: str = 'all', doy_end: int = None,
               year_end: int = None, overwrite: bool = False, translator: str = 'hybrid', samplerate: int = 30,
-              stream: str = 'R', mk: bool = False, weekly: bool = False, strip: bool = False):
+              stream: str = 'R', hrmn: str = '0000', fileperiod: str = 'D', mk: bool = False, weekly: bool = False, strip: bool = False):
     """
     rinex2snr translates RINEX files to a new file in SNR format. This function will also fetch orbit files for you.
     RINEX obs files are provided by the user or fetched from a long list of archives.
@@ -383,7 +385,7 @@ def rinex2snr(station: str, year: int, doy: int, snr: int = 66, orb: str = 'nav'
     args = {'station': station, 'year_list': year_list, 'doy_list': doy_list, 'isnr': snr, 'orbtype': orb,
             'rate': rate, 'dec_rate': dec, 'archive': archive, 'fortran': fortran, 'nol': nolook,
             'overwrite': overwrite, 'translator': translator, 'srate': samplerate, 'mk': mk,
-            'skipit': skipit, 'stream': stream, 'strip': strip}
+            'skipit': skipit, 'stream': stream, 'hrmn': hrmn, 'fileperiod': fileperiod, 'strip': strip}
 
     s1 = time.time()
     rnx.run_rinex2snr(**args)

--- a/gnssrefl/rinex2snr_cl.py
+++ b/gnssrefl/rinex2snr_cl.py
@@ -43,7 +43,7 @@ def parse_arguments():
     parser.add_argument("-samplerate", default=None, help="sample rate in sec (RINEX 3 only)", type=int)
     parser.add_argument("-stream", default=None, help="Set to R or S (RINEX 3 only)", type=str)
     parser.add_argument("-hrmn", default=None, help="Set hour and minute for RINEX 3 file name (sub-daily RINEX 3 only)", type=str)
-    parser.add_argument("-fileperiod", default=None, help="Set file period for RINEX 3 file name (sub-daily RINEX 3 only)", type=str)
+    parser.add_argument("-fileperiod", default=None, help="Set file period for RINEX 3 file name (sub-daily RINEX 3 only, e.g. 01M, 15M, 01H, 01D)", type=str)
     parser.add_argument("-mk", default=None, help="use True for uppercase station names ", type=str)
     parser.add_argument("-weekly", default=None, help="use True for weekly data translation", type=str)
     parser.add_argument("-strip", default=None, help="use True to reduce number of obs", type=str)
@@ -61,7 +61,7 @@ def parse_arguments():
 def rinex2snr(station: str, year: int, doy: int, snr: int = 66, orb: str = 'nav', rate: str = 'low', dec: int = 0,
               fortran: bool = False, nolook: bool = False, archive: str = 'all', doy_end: int = None,
               year_end: int = None, overwrite: bool = False, translator: str = 'hybrid', samplerate: int = 30,
-              stream: str = 'R', hrmn: str = '0000', fileperiod: str = 'D', mk: bool = False, weekly: bool = False, strip: bool = False):
+              stream: str = 'R', hrmn: str = '0000', fileperiod: str = '01D', mk: bool = False, weekly: bool = False, strip: bool = False):
     """
     rinex2snr translates RINEX files to a new file in SNR format. This function will also fetch orbit files for you.
     RINEX obs files are provided by the user or fetched from a long list of archives.


### PR DESCRIPTION
Adding two more options for specifying hour and minute of sub-daily RINEX 3 file (hrmn), as well as its file name period i.e. daily, hourly, minutely (fileperiod)