### PR TITLE
update dockerfile maintainer and trigger new image build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM unavdocker/gnssrefl_base
-LABEL maintainer="UNAVCO"
+LABEL maintainer="EARTHSCOPE"
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 


### PR DESCRIPTION
Updated [docker base image](https://gitlab.com/gnss_reflectometry/gnssrefl_docker_base_img) to use python:3.8-slim-buster image instead of plain ubuntu image to accommodate certs used by EarthScope SDK.
Tiny commit included here will trigger new build and document upstream change.