### PR TITLE
shortcourse rtd page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Welcome to the gnssrefl Documentation!
    pages/contributions_questions.md
    pages/new_station.md
    api
-
+..
    pages/sc_index
 
 .. note::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,5 +32,7 @@ Welcome to the gnssrefl Documentation!
    pages/new_station.md
    api
 
+   pages/sc_index
+
 .. note::
    These docs are still under development; feedback is appreciated.

--- a/docs/pages/sc_agenda_and_instructors.md
+++ b/docs/pages/sc_agenda_and_instructors.md
@@ -26,7 +26,7 @@
 # Course Instructors
 
 * [Kristine Larson](https://github.com/kristinemlarson) (University of Bonn, Germany) GNSS-IR, gnssrefl software
-![profile](https://gnss-reflections.org/static/images/tim_dittmann.jpg)
+<image src = "https://gnss-reflections.org/static/images/tim_dittmann.jpg" width="50px"></image>
 * [Felipe Nievinski](https://github.com/fgnievinski) (Uni. Federal do Rio Grande do Sul - Brazil) Theory, water levels, sensors
 ![profile](https://github.com/fgnievinski.png)
 * [Makan Karegar](https://github.com/MakanAKaregar) (Uni. Bonn- Germany) cheap GNSS-IR sensors, water levels 

--- a/docs/pages/sc_agenda_and_instructors.md
+++ b/docs/pages/sc_agenda_and_instructors.md
@@ -26,7 +26,7 @@
 # Course Instructors
 
 * [Kristine Larson](https://github.com/kristinemlarson) (University of Bonn, Germany) GNSS-IR, gnssrefl software
-![profile](https://github.com/kristinemlarson.png)
+![profile](https://gnss-reflections.org/static/images/tim_dittmann.jpg)
 * [Felipe Nievinski](https://github.com/fgnievinski) (Uni. Federal do Rio Grande do Sul - Brazil) Theory, water levels, sensors
 ![profile](https://github.com/fgnievinski.png)
 * [Makan Karegar](https://github.com/MakanAKaregar) (Uni. Bonn- Germany) cheap GNSS-IR sensors, water levels 

--- a/docs/pages/sc_agenda_and_instructors.md
+++ b/docs/pages/sc_agenda_and_instructors.md
@@ -26,7 +26,7 @@
 # Course Instructors
 
 * [Kristine Larson](https://github.com/kristinemlarson) (University of Bonn, Germany) GNSS-IR, gnssrefl software
-<image src = "https://gnss-reflections.org/static/images/tim_dittmann.jpg" width="50px"></image>
+
 * [Felipe Nievinski](https://github.com/fgnievinski) (Uni. Federal do Rio Grande do Sul - Brazil) Theory, water levels, sensors
 ![profile](https://github.com/fgnievinski.png)
 * [Makan Karegar](https://github.com/MakanAKaregar) (Uni. Bonn- Germany) cheap GNSS-IR sensors, water levels 
@@ -35,6 +35,6 @@
 * David Purnell (Laval University - Canada) water levels, cheap GNSS-IR sensors
 * Thomas Nylen (Danish Technical University, Denmark) - installing GNSS sites for GNSS-IR
 * [Kelly Enloe](https://github.com/k-enloe) (EarthScope - USA) – Jupyter notebooks, python, gnssrefl software
-![profile](https://github.com/k-enloe.png)
+<image src = "https://gnss-reflections.org/static/images/kellyenloe.jpg" width="100px"></image>
 * [Tim Dittmann](https://github.com/timdittmann) (EarthScope - USA) – python, gnssrefl software
-![profile](https://github.com/timdittmann.png)
+<image src = "https://gnss-reflections.org/static/images/tim_dittmann.jpg" width="100px"></image>

--- a/docs/pages/sc_agenda_and_instructors.md
+++ b/docs/pages/sc_agenda_and_instructors.md
@@ -1,0 +1,40 @@
+# Course Agenda
+
+## May 2: Introduction/Theory/Software
+- Overview KL
+- Basic Theory (FN) 
+- How to Run the Code (KL) 
+- Using the API (KL)
+
+## May 3: Hydrologic Applications
+- Snow and ice sheets (KL) 
+- Soil Moisture (KL) [Chew video](https://www.youtube.com/watch?v=ntnqD5O8LLo)            
+
+## May 4: Water Applications
+- overview (SW) 
+- invsnr method (DP) 
+- Lakes 
+- Rivers (MK)  
+- Tides (SW)                                                                           
+
+## May 5: Going Forward
+* Open source/science and how to contribute (TD)
+* Improvements needed for the software (KL,FN)
+* Best practices for new installations (TN)  
+* Low-cost sensors: (MK, DP, SW, FN)
+
+# Course Instructors
+
+* [Kristine Larson](https://github.com/kristinemlarson) (University of Bonn, Germany) GNSS-IR, gnssrefl software
+![profile](https://github.com/kristinemlarson.png)
+* [Felipe Nievinski](https://github.com/fgnievinski) (Uni. Federal do Rio Grande do Sul - Brazil) Theory, water levels, sensors
+![profile](https://github.com/fgnievinski.png)
+* [Makan Karegar](https://github.com/MakanAKaregar) (Uni. Bonn- Germany) cheap GNSS-IR sensors, water levels 
+![profile](https://github.com/MakanAKaregar.png)
+* Simon Williams (Nat. Ocean Ctr.- UK) water levels, tides, cheap GNSS-IR sensors
+* David Purnell (Laval University - Canada) water levels, cheap GNSS-IR sensors
+* Thomas Nylen (Danish Technical University, Denmark) - installing GNSS sites for GNSS-IR
+* [Kelly Enloe](https://github.com/k-enloe) (EarthScope - USA) – Jupyter notebooks, python, gnssrefl software
+![profile](https://github.com/k-enloe.png)
+* [Tim Dittmann](https://github.com/timdittmann) (EarthScope - USA) – python, gnssrefl software
+![profile](https://github.com/timdittmann.png)

--- a/docs/pages/sc_agenda_and_instructors.md
+++ b/docs/pages/sc_agenda_and_instructors.md
@@ -26,14 +26,17 @@
 # Course Instructors
 
 * [Kristine Larson](https://github.com/kristinemlarson) (University of Bonn, Germany) GNSS-IR, gnssrefl software
-
+<image src = "https://gnss-reflections.org/static/images/Kristine-NYC-crop.jpg" width="100px"></image>
 * [Felipe Nievinski](https://github.com/fgnievinski) (Uni. Federal do Rio Grande do Sul - Brazil) Theory, water levels, sensors
-![profile](https://github.com/fgnievinski.png)
+<image src = "https://spotlight.unavco.org/station-pages/p360/eo/scientistPhoto.jpg" width="100px"></image>
 * [Makan Karegar](https://github.com/MakanAKaregar) (Uni. Bonn- Germany) cheap GNSS-IR sensors, water levels 
-![profile](https://github.com/MakanAKaregar.png)
+<image src = "https://gnss-reflections.org/static/images/makan.jpg" width="100px"></image>
 * Simon Williams (Nat. Ocean Ctr.- UK) water levels, tides, cheap GNSS-IR sensors
+<image src = "https://gnss-reflections.org/static/images/Simon_Williams12.jpg" width="100px"></image>
 * David Purnell (Laval University - Canada) water levels, cheap GNSS-IR sensors
+<image src = "https://gnss-reflections.org/static/images/david_purnell2.jpg" width="100px"></image>
 * Thomas Nylen (Danish Technical University, Denmark) - installing GNSS sites for GNSS-IR
+<image src = "https://gnss-reflections.org/static/images/thomas_nylen.jpg" width="100px"></image>
 * [Kelly Enloe](https://github.com/k-enloe) (EarthScope - USA) – Jupyter notebooks, python, gnssrefl software
 <image src = "https://gnss-reflections.org/static/images/kellyenloe.jpg" width="100px"></image>
 * [Tim Dittmann](https://github.com/timdittmann) (EarthScope - USA) – python, gnssrefl software

--- a/docs/pages/sc_index.rst
+++ b/docs/pages/sc_index.rst
@@ -1,17 +1,14 @@
-########
+#####################################################
 2023 GNSS Interferometric Reflectometry Short Course
-########
+#####################################################
 
 May 2-5, 2023 Virtual Short Course.
 
 .. raw:: html
-   <p align=center>
-   <img src="https://www.unavco.org/data/gps-gnss/lib/images/station_images/TNPP.jpg" width=500>
-   </p>  
+   :url: https://www.unavco.org/data/gps-gnss/lib/images/station_images/TNPP.jpg 
 
 .. image:: _static/tnpp_rhdot_1.png
    :width: 600
-   for estimating environmental parameters using data from geodetic-quality GNSS sites.
 
 **The goals for this short course are to:**
 
@@ -23,10 +20,10 @@ May 2-5, 2023 Virtual Short Course.
 .. toctree::
    :maxdepth: 1
 
-   pages/sc_precourse.md
-   pages/sc_questions.md
-   pages/sc_agenda_and_instructors.md
-   pages/sc_media.md
+   sc_precourse.md
+   sc_questions.md
+   sc_agenda_and_instructors.md
+   sc_media.md
 
 Key Links:
 * `Earthscope Course page <https://www.earthscope.org/event/2023-gnss-ir-short-course/>`_ with registration, learning objectives and prereqs.

--- a/docs/pages/sc_index.rst
+++ b/docs/pages/sc_index.rst
@@ -2,7 +2,7 @@
 2023 GNSS Interferometric Reflectometry Short Course
 #####################################################
 May 2-5, 2023 Virtual Short Course.
-**Useful links**:
+
 `Earthscope Registration/Course page <https://www.earthscope.org/event/2023-gnss-ir-short-course/>`_ |
 `Software documentation <https://gnssrefl.readthedocs.io/en/latest/index.html>`_ |
 `Software installation <https://gnssrefl.readthedocs.io/en/latest/pages/README_install.html>`_
@@ -15,7 +15,7 @@ May 2-5, 2023 Virtual Short Course.
    sc_agenda_and_instructors.md
    sc_media.md
 
-.. image:: docs/_static/tnpp_rhdot_1.png
+.. image:: ../_static/tnpp_rhdot_1.png
    :width: 600
 
 **The goals for this short course are to:**

--- a/docs/pages/sc_index.rst
+++ b/docs/pages/sc_index.rst
@@ -1,0 +1,28 @@
+########
+2023 GNSS Interferometric Reflectometry Short Course
+########
+
+May 2-5, 2023 Virtual Short Course.
+
+GNSS-IR is a method for estimating environmental parameters using data from geodetic-quality GNSS sites.
+
+**The goals for this short course are to:**
+
+* introduce participants to the basic principles of the GNSS-IR method
+* provide support for users installing and running the gnssrefl code.
+* demonstrate and discuss gnssrefl use in practical sessions on snow accumulation, soil moisture and water levels.
+* provide guidance on GNSS-IR site location selection, use of low-cost sensors and contributing to open-source scientific software. 
+  
+.. toctree::
+   :maxdepth: 1
+
+   pages/sc_precourse.md
+   pages/sc_questions.md
+   pages/sc_agenda_and_instructors.md
+   pages/sc_media.md
+
+Key Links:
+* `Earthscope Course page <https://www.earthscope.org/event/2023-gnss-ir-short-course/>`_ with registration, learning objectives and prereqs.
+* `Software documentation <https://gnssrefl.readthedocs.io/en/latest/index.html>`_
+* `Software installation <https://gnssrefl.readthedocs.io/en/latest/pages/README_install.html>`_
+

--- a/docs/pages/sc_index.rst
+++ b/docs/pages/sc_index.rst
@@ -3,8 +3,9 @@
 ########
 
 May 2-5, 2023 Virtual Short Course.
-
-GNSS-IR is a method for estimating environmental parameters using data from geodetic-quality GNSS sites.
+.. image:: _static/tnpp_rhdot_1.png
+   :width: 600
+   for estimating environmental parameters using data from geodetic-quality GNSS sites.
 
 **The goals for this short course are to:**
 

--- a/docs/pages/sc_index.rst
+++ b/docs/pages/sc_index.rst
@@ -2,6 +2,10 @@
 2023 GNSS Interferometric Reflectometry Short Course
 #####################################################
 May 2-5, 2023 Virtual Short Course.
+**Useful links**:
+`Earthscope Registration/Course page <https://www.earthscope.org/event/2023-gnss-ir-short-course/>`_ |
+`Software documentation <https://gnssrefl.readthedocs.io/en/latest/index.html>`_ |
+`Software installation <https://gnssrefl.readthedocs.io/en/latest/pages/README_install.html>`_
 
 .. toctree::
    :maxdepth: 1
@@ -22,9 +26,6 @@ May 2-5, 2023 Virtual Short Course.
 * provide guidance on GNSS-IR site location selection, use of low-cost sensors and contributing to open-source scientific software. 
   
 
-**Useful links**:
-`Earthscope Registration/Course page <https://www.earthscope.org/event/2023-gnss-ir-short-course/>`_ |
-`Software documentation <https://gnssrefl.readthedocs.io/en/latest/index.html>`_ |
-`Software installation <https://gnssrefl.readthedocs.io/en/latest/pages/README_install.html>`_
+
 
 

--- a/docs/pages/sc_index.rst
+++ b/docs/pages/sc_index.rst
@@ -1,13 +1,17 @@
 #####################################################
 2023 GNSS Interferometric Reflectometry Short Course
 #####################################################
-
 May 2-5, 2023 Virtual Short Course.
 
-.. raw:: html
-   :url: https://www.unavco.org/data/gps-gnss/lib/images/station_images/TNPP.jpg 
+.. toctree::
+   :maxdepth: 1
 
-.. image:: _static/tnpp_rhdot_1.png
+   sc_precourse.md
+   sc_questions.md
+   sc_agenda_and_instructors.md
+   sc_media.md
+
+.. image:: docs/_static/tnpp_rhdot_1.png
    :width: 600
 
 **The goals for this short course are to:**
@@ -17,16 +21,10 @@ May 2-5, 2023 Virtual Short Course.
 * demonstrate and discuss gnssrefl use in practical sessions on snow accumulation, soil moisture and water levels.
 * provide guidance on GNSS-IR site location selection, use of low-cost sensors and contributing to open-source scientific software. 
   
-.. toctree::
-   :maxdepth: 1
 
-   sc_precourse.md
-   sc_questions.md
-   sc_agenda_and_instructors.md
-   sc_media.md
+**Useful links**:
+`Earthscope Registration/Course page <https://www.earthscope.org/event/2023-gnss-ir-short-course/>`_ |
+`Software documentation <https://gnssrefl.readthedocs.io/en/latest/index.html>`_ |
+`Software installation <https://gnssrefl.readthedocs.io/en/latest/pages/README_install.html>`_
 
-Key Links:
-* `Earthscope Course page <https://www.earthscope.org/event/2023-gnss-ir-short-course/>`_ with registration, learning objectives and prereqs.
-* `Software documentation <https://gnssrefl.readthedocs.io/en/latest/index.html>`_
-* `Software installation <https://gnssrefl.readthedocs.io/en/latest/pages/README_install.html>`_
 

--- a/docs/pages/sc_index.rst
+++ b/docs/pages/sc_index.rst
@@ -3,6 +3,12 @@
 ########
 
 May 2-5, 2023 Virtual Short Course.
+
+.. raw:: html
+   <p align=center>
+   <img src="https://www.unavco.org/data/gps-gnss/lib/images/station_images/TNPP.jpg" width=500>
+   </p>  
+
 .. image:: _static/tnpp_rhdot_1.png
    :width: 600
    for estimating environmental parameters using data from geodetic-quality GNSS sites.

--- a/docs/pages/sc_media.md
+++ b/docs/pages/sc_media.md
@@ -1,6 +1,8 @@
 # Slides and Materials
 
 ## Slides
+(Instructors upload slides or google drive open links)
 
 ## Recordings
+Links to course youtube
 

--- a/docs/pages/sc_media.md
+++ b/docs/pages/sc_media.md
@@ -1,0 +1,6 @@
+# Slides and Materials
+
+## Slides
+
+## Recordings
+

--- a/docs/pages/sc_precourse.md
+++ b/docs/pages/sc_precourse.md
@@ -1,0 +1,1 @@
+# Pre-course Install

--- a/docs/pages/sc_precourse.md
+++ b/docs/pages/sc_precourse.md
@@ -1,1 +1,3 @@
 # Pre-course Install
+
+(#TODO add pre course 'assignment')

--- a/docs/pages/sc_questions.md
+++ b/docs/pages/sc_questions.md
@@ -1,0 +1,11 @@
+# Questions and FAQ
+
+For installation questions, please join the slack channel [here](#todo insert slack link).
+
+(#todo insert guidelines about questions)
+
+Please use the search feature of Slack to try to avoid duplication, and **please help out your colleaugues when you might know a solution or have a suggestion.**
+
+For methodology-related questions, please email instructors or better still post a [GitHub issue](https://github.com/kristinemlarson/gnssrefl/issues).
+
+## FAQ

--- a/docs/pages/sc_questions.md
+++ b/docs/pages/sc_questions.md
@@ -8,4 +8,4 @@ Please use the search feature of Slack to try to avoid duplication, and **please
 
 For methodology-related questions, please email instructors or better still post a [GitHub issue](https://github.com/kristinemlarson/gnssrefl/issues).
 
-## FAQ
+## Installation FAQ


### PR DESCRIPTION
This PR sets up a 2023 shortcourse page in readthedocs for us to populate/update.

There will be a link on the main gnssrefl Table of Contents , but currently commented out (in docs/index.rst) until further developed.