### PR TITLE
Update use_sbas.md

### DIFF
--- a/docs/use_cases/use_sbas.md
+++ b/docs/use_cases/use_sbas.md
@@ -75,7 +75,7 @@ Save your analysis strategy:
 
 The next step is to estimate reflector heights. First do a single day using the plt option.
 
-<code>gnssir sbas 2021 1 -plt T</code>
+<code>gnssir sbas 2020 1 -plt T</code>
 
 <img src=../_static/sbas_gnssir_l1.png width=600/>	
 
@@ -92,7 +92,7 @@ And that is what we should expect.
 
 Go ahead and estimate reflector heights for all available days:
 
-<code>gnssir sbas 2021 1 -doy_end 366</code>
+<code>gnssir sbas 2020 1 -doy_end 366</code>
 
 Compute a daily average. Since we only have reflections in one geographic quadrant and are 
 only using GPS signals, we should not require as many points as we have done in other examples. 


### PR DESCRIPTION
In the "Estimate Lake Level" section in the first command, we make the SNR files for the year 2020, but the following two gnssir commands attempt to compute reflector heights for the year 2021, so they end with an error because there are no SNR files for that year. I changed them to 2020 and my plots look identical to the ones there, so it is just a typo and those two commands should say 2020 instead of 2021.