### PR TITLE
Update environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,8 @@ channels:
 - conda-forge
 - defaults
 dependencies:
+- sphinx<7
+- sphinx_rtd_theme
 - unzip
 - gfortran_linux-64
 - pip
@@ -14,7 +16,6 @@ dependencies:
 - pip:
      - myst_parser
      - nbsphinx
-#     - gnssrefl
      - numpydoc
      - sphinxcontrib-apidoc
      - git+https://github.com/kristinemlarson/gnssrefl.git

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,4 @@
-name: gnssrefl
+name: gnssrefl_rtd
 channels:
 - conda-forge
 - defaults

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - sphinx<7
 - sphinx_rtd_theme
 - unzip
-- gfortran_linux-64
+#- gfortran_linux-64
 - pip
 - wget
 - jupyter


### PR DESCRIPTION
RTD build fails due to 
`Theme error:
An error happened in rendering the page api.
Reason: UndefinedError("'style' is undefined")
`

Sphinx >=7 [does not yet support sphinx_rtd_theme](https://github.com/readthedocs/sphinx_rtd_theme/issues/1463).
Pinning sphinx to <7 to fix [issue 135.](https://github.com/kristinemlarson/gnssrefl/issues/135)