### PR TITLE
station_pos in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV ORBITS=/etc/gnssrefl/orbits
 ENV REFL_CODE=/etc/gnssrefl/refl_code
 
 RUN mkdir -p /etc/gnssrefl/refl_code/input/
-RUN mv /usr/src/gnssrefl/gnssrefl/gpt_1wA.pickle /etc/gnssrefl/refl_code/input/
-RUN mv /usr/src/gnssrefl/gnssrefl/station_pos.db /etc/gnssrefl/refl_code/Files/
+RUN cp /usr/src/gnssrefl/gnssrefl/gpt_1wA.pickle /etc/gnssrefl/refl_code/input/
+RUN cp /usr/src/gnssrefl/gnssrefl/station_pos.db /etc/gnssrefl/refl_code/Files/
 
 WORKDIR /usr/src/gnssrefl


### PR DESCRIPTION
The container ships with station_pos.db in refl_code/Files/, but the bind mount command (`-v $(pwd)/refl_code:/etc/gnssrefl/refl_code/`) issued by the user is overwriting it upon initial run command.

This PR repairs a previous Dockerfile commit so that station_pos.db is still in the expected alternative local path location (`gnssrefl/station_pos.db`).

More robust future updates might be to either:
- separate station_pos.db out of /refl_code  processed results
- Create an entry point script that copies this in AFTER the volume mount