### PR TITLE
Td meta 52

### DIFF
--- a/gnssrefl/make_meta.py
+++ b/gnssrefl/make_meta.py
@@ -71,7 +71,7 @@ def make_meta(
     el_height: float = None,
     man_input: bool = True,
     read_offset: bool = False,
-    overwrite: bool = False,git 
+    overwrite: bool = False,
 ):
     """
     Make a json file that includes equipment metadata information.
@@ -80,10 +80,10 @@ def make_meta(
     If station is in the UNR database, those lat/lon/el_height values are used. You may override those values
     with the optional inputs.
 
-    The default is for the user to enter these values; multiple calls will append entries to the metadata array, 
+    The default is for the user to enter these values; multiple calls will append entries to the metadata array,
     unless the user sets overwrite to True.
     The user can attempt to extract some of this information from the GAGE offset file.
-    [A caveat: this file is comprehensive for antennas changed by stations included in GAGE processing (n=~3k).  
+    [A caveat: this file is comprehensive for antennas changed by stations included in GAGE processing (n=~3k).
     Receivers are included, but incomplete.]
 
     Parameters

--- a/gnssrefl/make_meta.py
+++ b/gnssrefl/make_meta.py
@@ -1,0 +1,275 @@
+import argparse
+import json
+import os
+import subprocess
+import datetime
+import csv
+import sys
+import urllib.request
+import numpy as np
+import collections
+
+import gnssrefl.gps as g
+from gnssrefl.utils import str2bool
+
+
+def parse_arguments():
+    # user inputs the observation file information
+    parser = argparse.ArgumentParser()
+    # required arguments
+    parser.add_argument("station", help="station (lowercase)", type=str)
+    # optional inputs
+    parser.add_argument(
+        "-man_input_loc",
+        default=False,
+        type=str,
+        help="manually input station location (bool)",
+    )
+    parser.add_argument(
+        "-read_offset",
+        default=False,
+        type=str,
+        help="append meta from GAGE offset file",
+    )
+    parser.add_argument(
+        "-man_input", default=False, type=str, help="append meta from manual input"
+    )
+    parser.add_argument(
+        "-overwrite", default=False, type=str, help="create new meta file"
+    )
+
+    args = parser.parse_args().__dict__
+
+    # convert all expected boolean inputs from strings to booleans
+    boolean_args = [
+        "man_input_loc",
+        "read_offset",
+        "man_input",
+        "overwrite",
+    ]
+    args = str2bool(args, boolean_args)
+
+    # only return a dictionary of arguments that were added from the user - all other defaults will be set in code below
+    return {key: value for key, value in args.items() if value is not None}
+
+
+def make_meta(
+    station: str,
+    man_input_loc: bool = False,
+    read_offset: bool = False,
+    man_input: bool = True,
+    overwrite: bool = False,
+):
+    """
+    Make a json file that includes equipment metadata information.
+    It saves your inputs to a json file which by default is saved in REFL_CODE/input/<station>_meta.json.
+
+    The default is for the user to enter these values; multiple calls will append entries to the metadata array, unless the user sets overwrite to False.
+    The user can attempt to pull some of this information from the GAGE offset file.
+    [A caveat: this file is comprehensive for antenna's changed by stations included in GAGE processing (n=~3k).  Receivers are included, but incomplete.]
+
+    Parameters
+    ----------
+    station : str
+        4 character station ID.
+    man_input_loc : bool
+        set to true to manually input station coords (LLH or ECEF).
+        default is false, in which case they are pulled from unr db
+    read_offset : bool, optional
+        set to True to parse GAGE offset file. default is False.
+    man_input : bool, optional
+        set to True to manually input equipment metadata. default is True.
+    overwrite : bool, optional
+        set to True to overwrite existing metadata file. default is False.
+    """
+
+    # make sure environment variables exist
+    g.check_environ_variables()
+
+    # meta json object path
+    xdir = os.environ["REFL_CODE"]
+    outputdir = xdir + "/input"
+    if not os.path.isdir(outputdir):
+        subprocess.call(["mkdir", outputdir])
+    outputfile = outputdir + "/" + station + "_meta.json"
+
+    # If no overwrite and a file already exists, read in existing meta json
+    if (overwrite is False) and (os.path.isfile(outputfile)):
+        with open(outputfile) as json_file:
+            comp_dict = json.load(json_file)
+            meta_dict = comp_dict["meta"]
+
+    else:  # initialize empty meta_dict
+        comp_dict = get_coords(station, man_input_loc)
+        meta_dict = {}
+
+    # read in gage metadata file
+    if read_offset:
+        meta_dict = check_offsets(station, meta_dict)
+
+    if man_input:
+        meta_dict = meta_man_input(meta_dict)
+
+    # sort by date
+    meta_dict = collections.OrderedDict(sorted(meta_dict.items()))
+
+    # add metad to complete dictionary
+    comp_dict["meta"] = meta_dict
+    with open(outputfile, "w+") as outfile:
+        json.dump(comp_dict, outfile, indent=3)
+
+
+def get_coords(station, man_input_loc):
+    """
+    initializes metadata dictionary with lat lon ht keys, either from UNR database (default) or user entered
+    Parameters
+    ----------
+    station : str
+        4 character station ID.
+    man_input_loc : bool
+        set to true to manually input station coords (LLH or ECEF).
+        default is false, in which case they are pulled from unr db
+    Returns
+    ----------
+    comp_dict : dict
+        dictionary of metadata; keys 'lat','long','height' 'meta'.
+    """
+    if man_input_loc:
+        geod = input(
+            "You have chosen to manually enter the station location. \n Do you have geodetic coordinates? :"
+        )
+        geod = str2bool({"g": geod}, "g")["g"]
+
+        if geod:
+            lat = float(input("Enter the latitude:"))
+            long = float(input("Enter the longitude of the station: "))
+            height = float(input("Enter the height of the station: "))
+
+        else:
+            x = float(input("Enter the ECEF X coordinate:"))
+            y = float(input("Enter the Y coordinate: "))
+            z = float(input("Enter the Z coordinate: "))
+            lat, long, height = g.xyz2llhd([x, y, z])
+    else:
+        lat, long, height = g.queryUNR_modern(station)
+        if lat == 0:
+            print(
+                "Tried to find coordinates in our UNR database. gnssrefl wont work without knowing this"
+            )
+            sys.exit()
+
+    comp_dict = {
+        "station": station,
+        "lat": "{:.4f}".format(lat),
+        "long": "{:.4f}".format(long),
+        "height": "{:.4f}".format(height),
+        "meta": {},
+    }
+    return comp_dict
+
+
+def meta_man_input(meta_dict):
+    """
+    allows user to manually enter metadata information [Rx, Antenna, Dome, FW] at a given YMD
+    Parameters
+    ----------
+    meta_dict : dict
+        dictionary of metadata; keys 'dates','current','previous'.
+    Returns
+    ----------
+    meta_dict : dict
+        dictionary of metadata; keys 'dates','current','previous'.
+    """
+
+    year = input(
+        "You have chosen to manually enter a metadata state. \n Enter the 4 digit year: "
+    )
+    month = input("Enter the month number: ")
+    day = input("Enter the day of month number: ")
+    date_str = datetime.datetime(
+        year=int(year), day=int(day), month=int(month)
+    ).strftime("%Y-%m-%d")
+    receiver = input(" Enter the receiver brand and model: ")
+    antenna = input("Enter the antenna model: ")
+    dome = input("Enter the radome 4 digit type or * if unknown: ")
+    fw = input("Enter the receiver firmware or * if unknown: ")
+
+    meta_dict[date_str] = {
+        "state": receiver + " " + antenna + " " + dome + " " + fw,
+    }
+    return meta_dict
+
+
+def check_offsets(station, meta_dict):
+    """
+    check GAGE processing offset file for sources of possible gnssrefl timeseries offsets
+    currently only relevant for ~3k stations processed by GAGE
+    Parameters
+    ----------
+    station : str
+        4 character station ID.
+    meta_dict : dict
+        dictionary of metadata; keys 'dates','current','previous'.
+    Returns
+    ----------
+    meta_dict : dict
+        dictionary of metadata; keys 'dates','current','previous'.
+    """
+    offset_meta_dates = []
+    offset_meta_dict_list = []
+    url = "https://data.unavco.org/archive/gnss/products/offset/cwu.kalts_nam14.off"
+    response = urllib.request.urlopen(url)
+    lines = [l.decode("utf-8") for l in response.readlines()]
+    cr = csv.reader(lines)
+    for row in cr:
+        if row[0][1:5] == station.upper():
+            # DATE
+            year = int(row[0].split()[1])
+            month = int(row[0].split()[2])
+            day = int(row[0].split()[3])
+
+            offset_meta_dates.append(
+                datetime.datetime(year=year, day=day, month=month).strftime("%Y-%m-%d")
+            )
+
+            # Description
+            ofs = row[0].split()[11]
+            evt = row[0].split()[14]
+            # todo handle (rare) cases when order in file is swapped
+            if evt == "AN":
+                tmp_dict = {}
+                rx_array = np.empty(2, dtype="S15")
+                for i, state in enumerate(["state", "prior"]):
+                    receiver = rx_array[i] = (
+                        row[0].split()[24 - (i * 3)]
+                        + " "
+                        + row[0].split()[24 - (i * 3) + 1]
+                    )
+                    antenna = row[0].split()[19 - (i * 2)]
+                    dome = row[0].split()[29 - (i * 2)]
+                    tmp_dict[state] = "%s %s %s *" % (
+                        receiver,
+                        antenna,
+                        dome,
+                    )
+                swap = "ANT"
+                if rx_array[0] != rx_array[1]:
+                    swap = "ANT/RX"
+                tmp_dict["swap"] = swap
+            offset_meta_dict_list.append(tmp_dict.copy())
+
+    offset_meta_dict = dict(zip(offset_meta_dates, offset_meta_dict_list))
+    meta_dict = meta_dict | offset_meta_dict  # .copy()
+
+    if len(offset_meta_dates) == 0:
+        print("%s does not have an entry in GAGE offset file" % station)
+    return meta_dict
+
+
+def main():
+    args = parse_arguments()
+    make_meta(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/gnssrefl/make_meta.py
+++ b/gnssrefl/make_meta.py
@@ -75,7 +75,7 @@ def make_meta(
 ):
     """
     Make a json file that includes equipment metadata information.
-    It saves your inputs to a json file which by default is saved in REFL_CODE/input/<station>_meta.json.
+    It saves your inputs to a json file saved in REFL_CODE/input/<station>_meta.json.
 
     If station is in the UNR database, those lat/lon/el_height values are used. You may override those values
     with the optional inputs.
@@ -170,31 +170,6 @@ def get_coords(station, lat, lon, el_height):
     else:
         print("Using inputs:", lat, lon, el_height)
 
-    """
-    if man_input_loc:
-        geod = input(
-            "You have chosen to manually enter the station location. \n Do you have geodetic coordinates? :"
-        )
-        geod = str2bool({"g": geod}, "g")["g"]
-
-        if geod:
-            lat = float(input("Enter the latitude:"))
-            long = float(input("Enter the longitude of the station: "))
-            height = float(input("Enter the height of the station: "))
-
-        else:
-            x = float(input("Enter the ECEF X coordinate:"))
-            y = float(input("Enter the Y coordinate: "))
-            z = float(input("Enter the Z coordinate: "))
-            lat, long, height = g.xyz2llhd([x, y, z])
-    else:
-        lat, long, height = g.queryUNR_modern(station)
-        if lat == 0:
-            print(
-                "Tried to find coordinates in our UNR database. gnssrefl wont work without knowing this"
-            )
-            sys.exit()
-    """
     comp_dict = {
         "station": station,
         "lat": "{:.4f}".format(lat),

--- a/gnssrefl/make_meta.py
+++ b/gnssrefl/make_meta.py
@@ -71,7 +71,7 @@ def make_meta(
     el_height: float = None,
     man_input: bool = True,
     read_offset: bool = False,
-    overwrite: bool = False,
+    overwrite: bool = False,git 
 ):
     """
     Make a json file that includes equipment metadata information.
@@ -80,9 +80,11 @@ def make_meta(
     If station is in the UNR database, those lat/lon/el_height values are used. You may override those values
     with the optional inputs.
 
-    The default is for the user to enter these values; multiple calls will append entries to the metadata array, unless the user sets overwrite to False.
-    The user can attempt to pull some of this information from the GAGE offset file.
-    [A caveat: this file is comprehensive for antenna's changed by stations included in GAGE processing (n=~3k).  Receivers are included, but incomplete.]
+    The default is for the user to enter these values; multiple calls will append entries to the metadata array, 
+    unless the user sets overwrite to True.
+    The user can attempt to extract some of this information from the GAGE offset file.
+    [A caveat: this file is comprehensive for antennas changed by stations included in GAGE processing (n=~3k).  
+    Receivers are included, but incomplete.]
 
     Parameters
     ----------

--- a/setup.py
+++ b/setup.py
@@ -2,28 +2,42 @@ from setuptools import setup, find_packages
 from numpy.distutils.core import setup, Extension
 
 
-ext1 = Extension(name='gnssrefl.gpssnr', 
-        sources=['gnssrefl/gpssnr.f'], 
-        f2py_options=['--verbose'],
-        )
+ext1 = Extension(
+    name="gnssrefl.gpssnr",
+    sources=["gnssrefl/gpssnr.f"],
+    f2py_options=["--verbose"],
+)
 
-ext2 = Extension(name='gnssrefl.gnsssnr', 
-        sources=['gnssrefl/gnsssnr.f'], 
-        f2py_options=['--verbose'],
-        )
-ext3 = Extension(name='gnssrefl.gnsssnrbigger', 
-        sources=['gnssrefl/gnsssnrbigger.f'], 
-        f2py_options=['--verbose'],
-        )
-ext4 = Extension(name='gnssrefl.xnmeasnr', 
-        sources=['gnssrefl/xnmeasnr.f'], 
-        f2py_options=['--verbose'],
-        )
+ext2 = Extension(
+    name="gnssrefl.gnsssnr",
+    sources=["gnssrefl/gnsssnr.f"],
+    f2py_options=["--verbose"],
+)
+ext3 = Extension(
+    name="gnssrefl.gnsssnrbigger",
+    sources=["gnssrefl/gnsssnrbigger.f"],
+    f2py_options=["--verbose"],
+)
+ext4 = Extension(
+    name="gnssrefl.xnmeasnr",
+    sources=["gnssrefl/xnmeasnr.f"],
+    f2py_options=["--verbose"],
+)
 
 with open("README.md", "r") as readme_file:
     readme = readme_file.read()
 
-requirements = ["numpy","wget","scipy","matplotlib","requests","progress","astropy","simplekml","earthscope-sdk"]
+requirements = [
+    "numpy",
+    "wget",
+    "scipy",
+    "matplotlib",
+    "requests",
+    "progress",
+    "astropy",
+    "simplekml",
+    "earthscope-sdk",
+]
 setup(
     name="gnssrefl",
     version="1.4.2",
@@ -35,52 +49,53 @@ setup(
     url="https://github.com/kristinemlarson/gnssrefl/",
     packages=find_packages(),
     include_package_data=True,
-    entry_points ={ 
-        'console_scripts': [ 
-            'gnssir = gnssrefl.gnssir_cl:main',
-            'rinex2snr = gnssrefl.rinex2snr_cl:main',
-            'daily_avg = gnssrefl.daily_avg_cl:main',
-            'quickLook= gnssrefl.quickLook_cl:main',
-            'download_rinex = gnssrefl.download_rinex:main',
-            'download_orbits = gnssrefl.download_orbits:main',
-            'gnssir_input = gnssrefl.gnssir_input:main',
-            'ymd = gnssrefl.ymd:main',
-            'ydoy = gnssrefl.ydoy:main',
-            'xyz2llh = gnssrefl.xyz2llh:main',
-            'llh2xyz = gnssrefl.llh2xyz:main',
-            'prn2gps = gnssrefl.prn2gps:main',
-            'download_tides = gnssrefl.download_tides:main',
-            'subdaily= gnssrefl.subdaily_cl:main',
-            'gpsweek = gnssrefl.gpsweek:main',
-            'nmea2snr= gnssrefl.nmea2snr_cl:main',
-            'installexe= gnssrefl.installexe_cl:main',
-            'download_unr = gnssrefl.download_unr:main',
-            'query_unr= gnssrefl.query_unr:main',
-            'mp1mp2= gnssrefl.computemp1mp2:main',
-            'download_teqc = gnssrefl.download_teqc:main',
-            'rinex3_rinex2= gnssrefl.rinex3_rinex2:main',
-            'veg_multiyr= gnssrefl.veg_multiyr:main',
-            'check_rinex_file= gnssrefl.check_rinex_file:main',
-            'rinex3_snr= gnssrefl.rinex3_snr:main',
-            'rt_rinex3_snr= gnssrefl.rt_rinex3_snr:main',
-            'filesizes= gnssrefl.filesizes:main',
-            'invsnr= gnssrefl.invsnr_cl:main',
-            'invsnr_input= gnssrefl.invsnr_input:main',
-            'vwc_input= gnssrefl.vwc_input:main',
-            'phase= gnssrefl.quickPhase:main',
-            'refl_zones= gnssrefl.refl_zones_cl:main',
-            'vwc= gnssrefl.vwc_cl:main',
-            'smoosh= gnssrefl.smoosh:main',
-            'smoosh_snr= gnssrefl.smoosh_snr:main',
-            'quickplt= gnssrefl.quickplt:main',
-            'snowdepth= gnssrefl.snowdepth_cl:main',
-            'rh_plot= gnssrefl.rh_plot:main',
-            'nyquist= gnssrefl.nyquist_cl:main',
-            'pickle_dilemma= gnssrefl.pickle_dilemma:main',
-            ], 
-        },
+    entry_points={
+        "console_scripts": [
+            "gnssir = gnssrefl.gnssir_cl:main",
+            "rinex2snr = gnssrefl.rinex2snr_cl:main",
+            "daily_avg = gnssrefl.daily_avg_cl:main",
+            "quickLook= gnssrefl.quickLook_cl:main",
+            "download_rinex = gnssrefl.download_rinex:main",
+            "download_orbits = gnssrefl.download_orbits:main",
+            "gnssir_input = gnssrefl.gnssir_input:main",
+            "ymd = gnssrefl.ymd:main",
+            "ydoy = gnssrefl.ydoy:main",
+            "xyz2llh = gnssrefl.xyz2llh:main",
+            "llh2xyz = gnssrefl.llh2xyz:main",
+            "prn2gps = gnssrefl.prn2gps:main",
+            "download_tides = gnssrefl.download_tides:main",
+            "subdaily= gnssrefl.subdaily_cl:main",
+            "gpsweek = gnssrefl.gpsweek:main",
+            "nmea2snr= gnssrefl.nmea2snr_cl:main",
+            "installexe= gnssrefl.installexe_cl:main",
+            "download_unr = gnssrefl.download_unr:main",
+            "query_unr= gnssrefl.query_unr:main",
+            "mp1mp2= gnssrefl.computemp1mp2:main",
+            "download_teqc = gnssrefl.download_teqc:main",
+            "rinex3_rinex2= gnssrefl.rinex3_rinex2:main",
+            "veg_multiyr= gnssrefl.veg_multiyr:main",
+            "check_rinex_file= gnssrefl.check_rinex_file:main",
+            "rinex3_snr= gnssrefl.rinex3_snr:main",
+            "rt_rinex3_snr= gnssrefl.rt_rinex3_snr:main",
+            "filesizes= gnssrefl.filesizes:main",
+            "invsnr= gnssrefl.invsnr_cl:main",
+            "invsnr_input= gnssrefl.invsnr_input:main",
+            "vwc_input= gnssrefl.vwc_input:main",
+            "phase= gnssrefl.quickPhase:main",
+            "refl_zones= gnssrefl.refl_zones_cl:main",
+            "vwc= gnssrefl.vwc_cl:main",
+            "smoosh= gnssrefl.smoosh:main",
+            "smoosh_snr= gnssrefl.smoosh_snr:main",
+            "quickplt= gnssrefl.quickplt:main",
+            "snowdepth= gnssrefl.snowdepth_cl:main",
+            "rh_plot= gnssrefl.rh_plot:main",
+            "nyquist= gnssrefl.nyquist_cl:main",
+            "pickle_dilemma= gnssrefl.pickle_dilemma:main",
+            "make_meta= gnssrefl.make_meta:main",
+        ],
+    },
     install_requires=requirements,
-    ext_modules = [ext1,ext2,ext3,ext4],
+    ext_modules=[ext1, ext2, ext3, ext4],
     classifiers=[
         "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
This PR addresses issue: https://github.com/kristinemlarson/gnssrefl/issues/52

make_meta.py generates a simple station-level metadata store (in json) adjacent to the processing configuration json file.
The store includes station, lat, long, height and meta keys, where meta values are datetime keys associated with metadata state values (strings of Rx make/model, antenna, dome and FW).

the default is that the user manually input this metadata state information (`-man_input True`).
the user can extract antenna changes from the GAGE offset file (`-read_offset true`). This also adds prior and swap fields, as known metadata state changes are particularly useful information.  However, this file is incomplete wrt to number of stations (many, but not all) and changes (includes all antenna swaps, but only some receivers).  So the user should know it is is complimentary but not complete.

LLH is automatically pulled from the UNR database, unless the user includes `-lat -lon` args following the refl_zones workflow, in which case the user can manually add station coords.

Finally, the default is set to not overwrite any existing meta store, and append any new information the user adds, unless the user sets `-overwrite True`.