### PR TITLE
tagging docker versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
       
       - name: Add develop tag
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ghcr.io/${{ env.REPO }}:${{ env.GNSSREFL_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish
 on:
   push:
     branches:
-      - "td_docker-dev_issue164"
+      - "master"
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,14 +22,38 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Set environment variables for docker build
         run: |
           # Lowercase repo for Github Container Registry
           echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+          # Ensure tags are checked out
+          git fetch origin +refs/tags/*:refs/tags/*
+          # Version number from tag
+          echo "GNSSREFL_VERSION=$(git describe --tags)" >> $GITHUB_ENV
+
       - name: "Build:dockerimage"
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ env.REPO }}:latest
+          tags: ghcr.io/${{ env.REPO }}:${{ env.GNSSREFL_VERSION }} 
+          labels: |
+            org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
+            org.opencontainers.image.version=${{ env.GNSSREFL_VERSION }}
+            org.opencontainers.image.revision=${{ github.sha }}
+      
+      - name: Add develop tag
+        if: github.ref == 'refs/heads/main'
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: ghcr.io/${{ env.REPO }}:${{ env.GNSSREFL_VERSION }}
+          dst: ghcr.io/${{ env.REPO }}:develop
+
+      - name: Add latest tag
+        if: startsWith(github.ref, 'refs/tags/1')
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: ghcr.io/${{ env.REPO }}:${{ env.GNSSREFL_VERSION }}
+          dst: ghcr.io/${{ env.REPO }}:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish
 on:
   push:
     branches:
-      - "master"
+      - "td_docker-dev_issue164"
 
 jobs:
   build:


### PR DESCRIPTION
Addressing [issue 164](https://github.com/kristinemlarson/gnssrefl/issues/164), our intent is to tag each image.
`Latest` tag will be assigned to stable releases (new github tag).
`Develop` tag will be assigned to most recent push to head.

Approach repurposed from [MintPy developers - Thankyou!](https://github.com/insarlab/MintPy/blob/main/.github/workflows/build-docker.yml)