### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,25 +12,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Set environment variables for docker build
-        run: |
-          # Lowercase repo for Github Container Registry
-          echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
-          # Ensure tags are checked out
-          git fetch origin +refs/tags/*:refs/tags/*
-          # Version number from tag
-          echo "GNSSREFL_VERSION=$(git describe --tags)" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=true
 
       - name: "Build:dockerimage"
         uses: docker/build-push-action@v3
@@ -38,22 +39,5 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ env.REPO }}:${{ env.GNSSREFL_VERSION }} 
-          labels: |
-            org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
-            org.opencontainers.image.version=${{ env.GNSSREFL_VERSION }}
-            org.opencontainers.image.revision=${{ github.sha }}
-      
-      - name: Add develop tag
-        if: github.ref == 'refs/heads/master'
-        uses: akhilerm/tag-push-action@v2.1.0
-        with:
-          src: ghcr.io/${{ env.REPO }}:${{ env.GNSSREFL_VERSION }}
-          dst: ghcr.io/${{ env.REPO }}:develop
-
-      - name: Add latest tag
-        if: startsWith(github.ref, 'refs/tags/1')
-        uses: akhilerm/tag-push-action@v2.1.0
-        with:
-          src: ghcr.io/${{ env.REPO }}:${{ env.GNSSREFL_VERSION }}
-          dst: ghcr.io/${{ env.REPO }}:latest
+          tags: ${{ steps.meta.outputs.tags }} 
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
addressing failed container build due to tagging.

This updated code uses [docker/metadata-action](https://github.com/docker/metadata-action) to tag images.
Github [docs reference](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages).