### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: kristinemlarson/gnssrefl
           flavor: latest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
 
       - name: "Build:dockerimage"
         uses: docker/build-push-action@v3


### PR DESCRIPTION
Update repair of auto tag failure.

Addressing:
`Error: buildx failed with: ERROR: invalid tag "/:master": invalid reference format`