### PR TITLE
Add compression to NMEA pipeline

### DIFF
--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -207,6 +207,7 @@ def define_and_xz_snr(station,year,doy,snr):
         else:
             if os.path.isfile(fname3):
                 subprocess.call(['gunzip', fname3])
+                fname2 = fname3 #Switch file names for .xz to .gz, for returning proper name below
         # make sure the uncompression worked
         if os.path.isfile(fname):
             snre = True
@@ -3848,8 +3849,9 @@ def snr_exist(station,year,doy,snrEnd):
         snre = True # but needs to be uncompressed
         subprocess.call(['unxz', fname2])
     if os.path.isfile(fname3) and (not snre):
-            snre = True # but needs to be ungzipped 
-            subprocess.call(['gunzip', fname3])
+        snre = True # but needs to be ungzipped 
+        #subprocess.call(['gunzip', fname3])
+        #TS - Removed this line Aug 2023 to stop unecessary decompression in nmea2snr
 
     return snre 
 

--- a/gnssrefl/nmea2snr_cl.py
+++ b/gnssrefl/nmea2snr_cl.py
@@ -57,6 +57,8 @@ def main():
     sp3 : str, optional
         set to False or F to use low quality NMEA values for az and el angles.
         this is changed to a boolean in the nmea2snr command line tool.
+    compress: str
+        add compression to the snrfiles. Start with just '.gz' compression, can extend. 
 
     Examples
     --------
@@ -86,6 +88,7 @@ def main():
     parser.add_argument("-height", default=None, help="ellipsoid height,m", type=float)
     parser.add_argument("-sp3", default=None, help="boolean for whether sp3 orbits are used", type=str)
     parser.add_argument("-risky", default=None, help="boolean for whether sp3 orbits are used", type=str)
+    parser.add_argument("-compress", default=None, help="type of compression (.gz)", type=str)
 
     args = parser.parse_args()
 
@@ -112,7 +115,12 @@ def main():
             risky = True
         else:
             risky = False
-        
+            
+    if args.compress == None:
+        compress = None
+    else:
+        compress = args.compress
+    print('Compression:', compress)
 
     doy= args.doy
     if args.doy_end == None:
@@ -176,7 +184,7 @@ def main():
     if args.height is not None:
         height = args.height
     llh = [lat,lon,height]    
-    nmea.run_nmea2snr(station, year_list, doy_list, isnr, overwrite,dec,llh,sp3)
+    nmea.run_nmea2snr(station, year_list, doy_list, isnr, overwrite, dec, llh, sp3, compress)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add both reading/writing compression to the nmea2snr pipeline. My data was starting to really blow up my storage space, and I saw that gnssir has a compression option so I figured this would work along the way. I've tested the changes up through gnssir -- that seems to read the compressed SNR files no issue. I hope the small change to gps.py isn't breaking anything along the pipeline -- that was uncompressing any SNR files that already existed! I didn't see a call to it in gnssir so figured it was safe, but let me know if there is a better way to handle this and I can look at it again.