### PR TITLE
nmea2snr signal id sorting bug fix

### DIFF
--- a/gnssrefl/nmea2snr.py
+++ b/gnssrefl/nmea2snr.py
@@ -187,7 +187,6 @@ def NMEA2SNR(locdir, fname, snrfile, csnr, dec, year, doy, llh, sp3, compress):
         # make the snrfile
         gt.new_azel(station,tmpfile,snrfile,orbfile,csnr)
         print('Az/El Updated...')
-        return
     
     inx = np.argsort(T)  #Sort data by time
     


### PR DESCRIPTION
Hello,

I noticed that there's a bug in the nmea2snr module where the signal ID was not processed correctly and all SNR values from different signals were stored in the L1 column of the SNR file. Seems like this is due to a 'return' inserted in row 190, blocking further processing of the 'NMEA2SNR' function. Would be appreciated if you could have a look! - Naoya