### PR TITLE
Update environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
+- python=3.11
 - sphinx<7
 - sphinx_rtd_theme
 - unzip


### PR DESCRIPTION
RTD [failed to build](https://readthedocs.org/api/v2/build/22452816.txt) raised in issue [208](https://github.com/kristinemlarson/gnssrefl/issues/208).
@kristinemlarson [identified a resolution](https://stackoverflow.com/questions/77364550/attributeerror-module-pkgutil-has-no-attribute-impimporter-did-you-mean) of pinning the python version to <3.12.

This PR will test pinning RTD python version to 3.11 using [RTD+mamba build tools](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python).  