### PR TITLE
Update subdaily.py

### DIFF
--- a/gnssrefl/subdaily.py
+++ b/gnssrefl/subdaily.py
@@ -86,7 +86,7 @@ def get_knot_loc(tmin, tmax, knots_per_day, original=False, quantized=True, inte
         
     return knot_loc
 
-#"""
+"""
 # Tests:
 print(get_knot_loc(0.0, 2.0, 2, original=True))
 print(get_knot_loc(0.0, 2.0, 2, quantized=False, interior=True))


### PR DESCRIPTION
make spline knots more repeatable (EXPERIMENTAL)
the integration with existing code is rough and incomplete.
but a new function to calculate the knot locations was tested:
https://colab.research.google.com/drive/1ckRF2rSNk2UM9osjxb_xhgHNEtBnTGot?usp=sharing

```
print(get_knot_loc(0.0, 2.0, 2, original=True))
print(get_knot_loc(0.0, 2.0, 2, quantized=False, interior=True))
print(get_knot_loc(0.0, 2.0, 2, quantized=False, interior=False))
print(get_knot_loc(0.1, 2.2, 2, quantized=False, interior=True))
print(get_knot_loc(0.1, 2.2, 2, quantized=False, interior=False))
print(get_knot_loc(0.0, 2.0, 2, quantized=True, interior=True))
print(get_knot_loc(0.0, 2.0, 2, quantized=True, interior=False))
print(get_knot_loc(0.1, 2.2, 2, quantized=True, interior=True))
print(get_knot_loc(0.1, 2.2, 2, quantized=True, interior=False))

#Results:
#[0.01041667 0.67013889 1.32986111 1.98958333]
#[0.  0.5 1.  1.5 2. ]
#[0.  0.5 1.  1.5 2. ]
#[0.1 0.6 1.1 1.6 2.1]
#[0.1 0.6 1.1 1.6 2.1 2.6]
#[0.  0.5 1.  1.5 2. ]
#[0.  0.5 1.  1.5 2. ]
#[0.5 1.  1.5 2. ]
#[0.  0.5 1.  1.5 2.  2.5]

```