### PR TITLE
Add feature: get orbit files from Wuhan FTP

### DIFF
--- a/gnssrefl/rinex2snr.py
+++ b/gnssrefl/rinex2snr.py
@@ -479,7 +479,7 @@ def conv2snr(year, doy, station, option, orbtype,receiverrate,dec_rate,archive,f
                     if (orbtype  == 'gps') or ('nav' in orbtype):
                         gpssnr.foo(in1,in2,in3,in4,in5,in6)
                     else:
-                        if (orbtype == 'ultra') or (orbtype == 'wum'):
+                        if orbtype in ['ultra', 'wum', 'wum2']:
                             print('Using an ultrarapid orbit', orbtype)
                             gnsssnrbigger.foo(in1,in2,in3,in4,in5,in6)
                         else:

--- a/gnssrefl/rinex2snr_cl.py
+++ b/gnssrefl/rinex2snr_cl.py
@@ -206,6 +206,10 @@ def rinex2snr(station: str, year: int, doy: int, snr: int = 66, orb: str = None,
 
             gfr : GFZ rapid, GPS, Galileo and Glonass, since May 17 2021
 
+            wum : Wuhan ultra-rapid, from CDDIS
+
+            wum2 : Wuhan ultra-rapid, from Wuhan FTP
+
             rapid : GFZ rapid, multi-GNSS
 
             ultra: GFZ ultra-rapid, multi-GNSS
@@ -349,7 +353,8 @@ def rinex2snr(station: str, year: int, doy: int, snr: int = 66, orb: str = None,
     # currently allowed orbit types - shanghai removed 2020sep08
     #
     orbit_list = ['gps', 'gps+glo', 'gnss', 'nav', 'igs', 'igr', 'jax', 'gbm',
-                  'grg', 'wum', 'gfr', 'esa', 'ultra', 'rapid', 'gnss2','nav-sopac','nav-esa','nav-cddis','gnss3','gnss-gfz']
+                  'grg', 'wum', 'wum2', 'gfr', 'esa', 'ultra', 'rapid', 'gnss2',
+                  'nav-sopac', 'nav-esa', 'nav-cddis', 'gnss3', 'gnss-gfz']
     if orb not in orbit_list:
         print('You picked an orbit type I do not recognize. Here are the ones I allow')
         print(orbit_list)


### PR DESCRIPTION
Adds a function to get sp3 orbit files from the Wuhan IGS FTP (ftp://igs.gnsswhu.cn) site using command line argument "-orb wum2". The existing argument "-orb wum" attempts to get Wuhan orbit files from CDDIS, but there is substantial latency for the orbit files to appear in CDDIS. This PR allows the user to get the orbits directly from Wuhan where they are available much earlier.