### PR TITLE
bugfix rinex 3 deletion

### DIFF
--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -3775,7 +3775,7 @@ def new_rinex3_rinex2(r3_filename,r2_filename,dec=1,gpsonly=False):
         #print('gfzrnx rinex3 to rinex 2:', round(s2-s1,2), ' seconds')
 
         print('remove rnx version of RINEX 3 file')
-        subprocess.call(['rm', '-f', r3_filename_new ])
+        subprocess.call(['rm', '-f', r3_filename])
 
     return fexists
 


### PR DESCRIPTION
When deleting the rinex 3 file after conversion to rinex 2, the variable "r3_filename_new" does not get initialized if the rinex 3 file doesn't have a .crx file extension, causing a critical error with the rinex2snr conversion.