### PR TITLE
fix: vwc_input ignores extension when looking for results

### DIFF
--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -103,6 +103,8 @@ def vwc_input(station: str, year: int, fr: int = 20, min_tracks: int = 100,
     # it failed and there is no need for it at this time
     y = year
     data_dir = xdir / str(y) / 'results' / station
+    if extension:
+        data_dir = data_dir / extension  # add extension subdirectory if specified
     result_files = read_files_in_dir(data_dir)
     if result_files == None:
         print('Exiting.')


### PR DESCRIPTION
Problem:
When using vwc_input with an extension (e.g., -extension half_sky), it incorrectly looks for results in the default station directory instead of the extension subdirectory.

Details:
1. vwc_input looks in: gnss_refl/2017/results/p038/
2. But with extensions, results are in a subdirectory, e.g: gnss_refl/2017/results/p038/half_sky/
3. If the default directory is empty, this causes 'gnssir_results' to be an empty list, leading to the error shown below:

![failed_no_results](https://github.com/user-attachments/assets/0960bcef-68f2-4319-8b0b-d3f43c1cd39e)

4. If the default directory is not empty (e.g. gnssir has been run without an extension), vwc_input will use that data, not the extension directory data.

Steps to reproduce:
1. On a new site with no existing results, run gnssir with the --extension flag:
    ```
    gnssir p038 2017 1 -doy_end 365 -extension half_sky
    ```
    This will work and populate the "results/p038/half_sky/" directory.

2. Run vwc_input with the same extension:
    ```
    vwc_input p038 2017 -extension half_sky
    ```
   And you will see the error above.

Fix:
Updates the data directory path construction to include the extension subdirectory when specified.

__________________

Although I understand it may be possible that vwc_input does this on purpose? Anyway, thanks for maintaining this package :) 