### PR TITLE
fix: bugs when minvalperday = 1

### DIFF
--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -260,7 +260,7 @@ def read_apriori_rh(station,fr):
         apriori_path_f = myxdir + '/input/' + station + '_phaseRH_L1.txt'
 
     if os.path.exists(apriori_path_f):
-        result = np.loadtxt(apriori_path_f, comments='%')
+        result = np.loadtxt(apriori_path_f, comments='%', ndmin=2)
         print('Using: ', apriori_path_f) 
     else:
         print('Average RH file does not exist')

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -812,7 +812,7 @@ def write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir):
             # put in amplitude criteria to keep out bad L2P results
                 ph1 = phase[(y1 == requested_year) & (d1 == doy) & (phase > -10) & (amp > 0.65)]
                 amp1 = amp[(y1 == requested_year) & (d1 == doy) & (phase > -10) & (amp > 0.65)]
-                if (len(ph1) > minvalperday):
+                if (len(ph1) >= minvalperday):
                     newl = [requested_year, doy, np.mean(ph1), len(ph1)]
                 # i think you normalize the individual satellites before this step
                 #namp = qp.normAmp(amp1,0.15)


### PR DESCRIPTION
fix: bugs when minvalperday = 1

Issue 1: 
When there is only a single uncommented track in the "{station}_phaseRH" file, vwc will return this error: 
```
nr = len(tracks[:,1])
         ~~~~~~^^^^^
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```
The bug occurs because NumPy returns a 1D array instead of 2D when there's only one row of data.

Issue 2:
 When minvalperday is set as 1 in "{station}.json", running vwc with the same phaseRH file as above (only a single uncommented line): 
```
Number of daily phase measurements  0
No results - perhaps minvalperday or min_req_pts_track are too stringent
```
This bug occurs due to using > instead of >=

Fixes
* Added ndmin=2 parameter to np.loadtxt() to ensure 2D array output regardless of row count
* Changed the minvalperday comparison from > to >=