### PR TITLE
fix: Remove unused code causing FileNotFoundError in read_apriori_rh

### DIFF
--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -249,10 +249,6 @@ def read_apriori_rh(station,fr):
         column 7 is maximum azimuth degrees for the quadrant
     """
     result = []
-    # do not have time to use this
-    file_manager = FileManagement(station, FileTypes.apriori_rh_file)
-    apriori_results = file_manager.read_file(comments='%')
-    # for l2c
     myxdir = os.environ['REFL_CODE']
     apriori_path_f = myxdir + '/input/' + station + '_phaseRH.txt'
 


### PR DESCRIPTION
**Issue:** When attempting to process L1 data with the phase command using `-fr 1`, the function 
fails with an error because it tries to read the phaseRH file for the default L2C data, which doesn't exist because I had not created it with vwc_input (this station has no L2C):

```
FileNotFoundError: refl_code/input/xxxx_phaseRH.txt does not exist.
```

**Steps to recreate:** 

(for a new station xxx with no prior results)
```
rinex2snr xxxx 2024 1
gnssir_input -fr 1
gnssir xxxx 2024 1
vwc_input xxxx 2024 -fr 1
phase xxxx 2024 1 -fr 1 <---- fails with above error
```

**Fix:** A simple fix is to remove these 4 lines, because they are not being used any more and the function works identically without them:

```
 # do not have time to use this
 file_manager = FileManagement(station, FileTypes.apriori_rh_file)
  apriori_results = file_manager.read_file(comments='%')
  # for l2c
```
