### PR TITLE
Add support for full filepaths in rinex3_rinex2.py

### DIFF
--- a/gnssrefl/rinex3_rinex2.py
+++ b/gnssrefl/rinex3_rinex2.py
@@ -37,6 +37,7 @@ def main():
 
     args = parser.parse_args()
     rinex3 = args.rinex3
+    rinex3_basename = os.path.basename(rinex3)  # Extract just the filename
 
     gexe = g.gfz_version()
 
@@ -45,9 +46,9 @@ def main():
     if (args.gpsonly == 'True') or (args.gpsonly == 'T'):
         gpsonly = True
 
-    station = rinex3[0:4].lower()
-    cyyyy = rinex3[12:16]
-    cdoy = rinex3[16:19]
+    station = rinex3_basename[0:4].lower()
+    cyyyy = rinex3_basename[12:16]
+    cdoy = rinex3_basename[16:19]
     year = int(cyyyy)
     doy = int(cdoy)
 


### PR DESCRIPTION
**Issue:** Currently, rinex3_rinex2 only works with filenames in the current directory. When providing a full filepath like this:

```
rinex3_rinex2 /home/user/Scripts/gnssIR/data/refl_code/2025/rinex/gns2/GNS200AUS_R_20250730000_01D_30S_MO.rnx
```

It fails with ValueError because it extracts values from the wrong string index:

```
ValueError: invalid literal for int() with base 10: '/Scr'
```

**Fix:** Extract the basename before parsing filename components:

```python
rinex3 = args.rinex3
rinex3_basename = os.path.basename(rinex3)  # Extract just the filename
station = rinex3_basename[0:4].lower()
cyyyy = rinex3_basename[12:16]
cdoy = rinex3_basename[16:19]
```

This allows the tool to be used with full filepaths instead of having to first navigate to the directory containing the file. It is backwards compatible because the basename of a file ```GNS200AUS_R_20250730000_01D_30S_MO.rnx``` is itself. 