### PR TITLE
Add extension support to vwc_input, phase, and vwc commands

### DIFF
--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -4754,12 +4754,9 @@ def l2c_l5_list(year,doy):
 
 def l1c_list(year, doy):
     """
-    Creates a satellite list of L1C transmitting satellites
-    for a given year/doy
+    Creates a satellite list of L1C transmitting satellites for a given year/doy
 
     L1C is only transmitted by GPS Block III satellites launched since December 2018.
-    Note: L1C signals are currently pre-operational and marked as "unhealthy"
-    until sufficient operational capability is established.
 
     Parameters
     ----------

--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -4778,6 +4778,7 @@ def l1c_list(year, doy):
     # GPS Block III satellites with L1C capability
     # Format: [PRN, launch_year, launch_doy]
     # Data compiled from GPS launch records as of July 2025
+    # https://en.wikipedia.org/wiki/List_of_GPS_satellites#Block_III
     l1c = np.array([
         [4, 2018, 357],  # GPS III SV01 "Vespucci" - Dec 23, 2018
         [18, 2019, 234],  # GPS III SV02 "Magellan" - Aug 22, 2019

--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -4752,6 +4752,51 @@ def l2c_l5_list(year,doy):
     return l2csatlist, l5satlist
 
 
+def l1c_list(year, doy):
+    """
+    Creates a satellite list of L1C transmitting satellites
+    for a given year/doy
+
+    L1C is only transmitted by GPS Block III satellites launched since December 2018.
+    Note: L1C signals are currently pre-operational and marked as "unhealthy"
+    until sufficient operational capability is established.
+
+    Parameters
+    ----------
+    year: int
+        full year
+    doy: integer
+        day of year
+
+    Returns
+    -------
+    l1csatlist : numpy array (int)
+        satellites possibly transmitting L1C signal
+
+    """
+
+    # GPS Block III satellites with L1C capability
+    # Format: [PRN, launch_year, launch_doy]
+    # Data compiled from GPS launch records as of July 2025
+    l1c = np.array([
+        [4, 2018, 357],  # GPS III SV01 "Vespucci" - Dec 23, 2018
+        [18, 2019, 234],  # GPS III SV02 "Magellan" - Aug 22, 2019
+        [23, 2020, 182],  # GPS III SV03 "Columbus" - Jun 30, 2020
+        [20, 2020, 310],  # GPS III SV04 "Henson" - Nov 5, 2020
+        [22, 2021, 168],  # GPS III SV05 "Neil Armstrong" - Jun 17, 2021
+        [19, 2023, 18],  # GPS III SV06 "Amelia Earhart" - Jan 18, 2023
+        [21, 2024, 351],  # GPS III SV07 "Sally Ride" - Dec 16, 2024
+        [26, 2025, 150],  # GPS III SV08 "Katherine Johnson" - May 30, 2025
+        # Additional GPS III satellites (SV09, SV10) expected 2025-2026
+    ])
+
+    # Find satellites launched before the specified date
+    ij = (l1c[:, 1] + l1c[:, 2] / 365.25) < (year + doy / 365.25)
+    l1csatlist = l1c[ij, 0]
+
+    return l1csatlist
+
+
 def binary(string):
     """
     changes python string to bytes for use in

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -972,6 +972,11 @@ def load_phase_filter_out_snow(station, year1, year2, fr, snowmask, extension = 
     fname = output_dir / 'raw.phase'
 
     dataexist, results = load_sat_phase(station, year1,year2, fr, extension)
+    if not dataexist:
+        print("No phase data was found to load.")
+        # Return empty values to prevent a crash downstream
+        return False, [], [], [], [], [], [], [], [], [], [], []
+
     results = results.T # backwards for consistency
     if snowmask == None:
         nr,nc = np.shape(results)

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -364,7 +364,7 @@ def get_vwc_frequency(station: str, extension: str, fr_cmd: str = None):
     # Always return a list
     return [final_fr]
 
-def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, screenstats, compute_lsp,gzip):
+def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, screenstats, compute_lsp,gzip, extension=''):
     """
     This does the main work of estimating phase and other parameters from the SNR files
     it uses tracks that were predefined by the apriori.py code
@@ -420,9 +420,13 @@ def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, scre
 
     else:
         header = "Year DOY Hour   Phase   Nv  Azimuth  Sat  Ampl emin emax  DelT aprioriRH  freq estRH  pk2noise LSPAmp\n(1)  (2)  (3)    (4)   (5)    (6)    (7)  (8)  (9)  (10)  (11)   (12)     (13)  (14)    (15)    (16)"
-        file_manager = FileManagement(station, FileTypes.phase_file, year, doy, file_not_found_ok=True)
-        print(f"Saving phase file to: {file_manager.get_file_path()}")
-        with open(file_manager.get_file_path(), 'w') as my_file:
+        output_path = FileManagement(station, FileTypes.phase_file, year, doy).get_file_path()
+        if extension:
+            output_path = output_path.parent / extension / output_path.name
+            output_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure the new subdirectory exists
+
+        print(f"Saving phase file to: {output_path}")
+        with open(output_path, 'w') as my_file:
             np.savetxt(my_file, [], header=header, comments='%')
             # read the SNR file into memory
             sat, ele, azi, t, edot, s1, s2, s5, s6, s7, s8, snr_exists = read_snr.read_one_snr(obsfile, 1)

--- a/gnssrefl/quickPhase.py
+++ b/gnssrefl/quickPhase.py
@@ -141,10 +141,10 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
 
             for d in date_range:
                 print('Analyzing year/day of year ' + str(y) + '/' + str(d))
-                qp.phase_tracks(station, y, d, snr, fr_list, e1, e2, pele, plt, screenstats, compute_lsp, gzip)
+                qp.phase_tracks(station, y, d, snr, fr_list, e1, e2, pele, plt, screenstats, compute_lsp, gzip, extension)
     else:
         for d in np.arange(doy, doy_end + 1):
-            qp.phase_tracks(station, year, d, snr, fr_list, e1, e2, pele, plt, screenstats, compute_lsp, gzip)
+            qp.phase_tracks(station, year, d, snr, fr_list, e1, e2, pele, plt, screenstats, compute_lsp, gzip, extension)
 
 
 def main():

--- a/gnssrefl/quickPhase.py
+++ b/gnssrefl/quickPhase.py
@@ -13,9 +13,10 @@ def parse_arguments():
     parser.add_argument("year", help="year", type=int)
     parser.add_argument("doy", help="doy", type=int)
     parser.add_argument("-snr", default=None, help="snr file ending", type=int)
-    parser.add_argument("-fr", default=None, help="frequency (use all if you want both 1 and 20)", type=str)
+    parser.add_argument("-fr", default=None, help="frequency (e.g. 1, 20, or 'all'). If not set, reads from json.", type=str)
     parser.add_argument("-doy_end", "-doy_end", default=None, type=int, help="doy end")
     parser.add_argument("-year_end", "-year_end", default=None, type=int, help="year end")
+    parser.add_argument("-extension", default='', help="analysis extension for json file", type=str)
     parser.add_argument("-e1", default=None, type=float),
     parser.add_argument("-e2", default=None, type=float),
     parser.add_argument("-plt", default=None, type=str, help="plots come to the screen - which you do not want!")
@@ -32,8 +33,8 @@ def parse_arguments():
     return {key: value for key, value in args.items() if value is not None}
 
 
-def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end: int = None, snr: int = 66, 
-        fr: str = '20', e1: float = 5, e2: float = 30, plt: bool = False, screenstats: bool = False, gzip: bool = True):
+def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end: int = None, snr: int = 66,
+        fr: str = None, e1: float = 5, e2: float = 30, plt: bool = False, screenstats: bool = False, gzip: bool = True, extension: str = ''):
     """
     quickphase computes phase, which are subquently used in vwc. The command line call is phase
     (which maybe we should change).
@@ -100,19 +101,15 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
         print('Station name must be four characters long. Exiting.')
         sys.exit()
 
-    if fr == 'all':
-        fr_list = [1, 20]
-        ex = qp.apriori_file_exist(station,20)
-        if (not ex):
-            print('No apriori RH file exists. Run vwc_input')
-            sys.exit()
-    else:
-        fr_list = [int(fr)]
-        ex = qp.apriori_file_exist(station,int(fr))
-        if (not ex):
-            print('No apriori RH file exists. Run vwc_input')
-            sys.exit()
+    # Use the helper function to get the list of frequencies.
+    fr_list = qp.get_vwc_frequency(station, extension, fr)
 
+    # Check that an apriori file exists for each requested frequency.
+    for f in fr_list:
+        ex = qp.apriori_file_exist(station, f)
+        if not ex:
+            print(f'No apriori RH file exists for frequency {f}. Please run vwc_input.')
+            sys.exit()
 
     # in case you want to analyze multiple days of data
     if not doy_end:

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -165,7 +165,7 @@ def vwc(station: str, year: int, year_end: int = None, fr: int = 20, plt: bool =
 
     # pick up all the phase data. unwrapped phase is stored in the results variable
     data_exist, year_sat_phase, doy, hr, phase, azdata, ssat, rh, amp_lsp,amp_ls,ap_rh, results = \
-            qp.load_phase_filter_out_snow(station, year, year_end, fr,snow_file)
+            qp.load_phase_filter_out_snow(station, year, year_end, fr,snow_file, extension)
 
 
     if not data_exist:
@@ -442,7 +442,7 @@ def vwc(station: str, year: int, year_end: int = None, fr: int = 20, plt: bool =
         qp.daily_phase_plot(station, fr,datetime_dates, tv,xdir,subdir,hires_figs)
 
         # convert daily phase values to volumetric water content
-        qp.convert_phase(station, year, year_end, plt,fr,tmin,tmax,polyorder,circles,subdir,hires_figs)
+        qp.convert_phase(station, year, year_end, plt,fr,tmin,tmax,polyorder,circles,subdir,hires_figs, extension)
 
 
 def main():

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -38,7 +38,7 @@ def parse_arguments():
     parser.add_argument("-auto_removal", default=None, type=str, help="Whether you want to remove bad tracks automatically, default is False")
     parser.add_argument("-hires_figs", default=None, type=str, help="Whether you want eps instead of png files")
     parser.add_argument("-advanced", default=None, type=str, help="Whether you want to implement advanced veg model (in development)")
-    parser.add_argument("-extension", default=None, type=str, help="which extension -if any - used in analysis json")
+    parser.add_argument("-extension", default='', type=str, help="which extension -if any - used in analysis json")
 
     g.print_version_to_screen()
 

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -24,7 +24,7 @@ def parse_arguments():
     parser.add_argument("station", help="station", type=str)
     parser.add_argument("year", help="year", type=int)
     parser.add_argument("-year_end", default=None, help="year_end", type=int)
-    parser.add_argument("-fr", help="frequency", type=int)
+    parser.add_argument("-fr", help="frequency", type=str)
     parser.add_argument("-plt", default=None, type=str, help="boolean for plotting to screen")
     parser.add_argument("-screenstats", default=None, type=str, help="boolean for plotting statistics to screen")
     parser.add_argument("-min_req_pts_track", default=None, type=int, help="min number of points for a track to be kept. Default is 100")
@@ -50,7 +50,7 @@ def parse_arguments():
     return {key: value for key, value in args.items() if value is not None}
 
 
-def vwc(station: str, year: int, year_end: int = None, fr: int = 20, plt: bool = True, screenstats: bool = False, 
+def vwc(station: str, year: int, year_end: int = None, fr: str = None, plt: bool = True, screenstats: bool = False,
         min_req_pts_track: int = None, polyorder: int = -99, minvalperday: int = None, 
         snow_filter: bool = False, subdir: str=None, tmin: float=None, tmax: float=None, 
         warning_value : float=None, auto_removal : bool=False, hires_figs : bool=False, advanced : bool=False, extension:str=None ):
@@ -144,7 +144,15 @@ def vwc(station: str, year: int, year_end: int = None, fr: int = 20, plt: bool =
     # azimuth list, starting point only (i.e. 270 means 270 thru 360)
     azlist = [270, 0, 180,90 ]
     # consistency with old adv vegetation code
-    oldquads = [2, 1, 3, 4] # number system from pboh2o, only used for 
+    oldquads = [2, 1, 3, 4] # number system from pboh2o, only used for
+
+    # Default frequency selection logic (from json if none supplied by command line)
+    fr_list = qp.get_vwc_frequency(station, extension, fr)
+    if len(fr_list) > 1:
+        print("Error: vwc can only process one frequency at a time.")
+        sys.exit()
+    # Get the single frequency from the list
+    fr = fr_list[0]
 
     # pick up the parameters used for this code
     minvalperday, tmin, tmax, min_req_pts_track, freq, year_end, subdir, plt, \

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from gnssrefl.gps import l2c_l5_list
 from gnssrefl.utils import read_files_in_dir, FileTypes, FileManagement
 import gnssrefl.gnssir_v2 as guts2
-
+from gnssrefl.phase_functions import get_vwc_frequency
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
@@ -29,7 +29,7 @@ def parse_arguments():
     return {key: value for key, value in args.items() if value is not None}
 
 
-def vwc_input(station: str, year: int, fr: int = None, min_tracks: int = 100, minvalperday : int = 10,
+def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, minvalperday : int = 10,
               extension : str='', tmin : float=0.05, tmax : float=0.5, warning_value :float=5.5 ):
     """
     Sets inputs for the estimation of vwc (volumetric water content).  Picks up reflector height (RH) results for a 
@@ -96,6 +96,15 @@ def vwc_input(station: str, year: int, fr: int = None, min_tracks: int = 100, mi
     if (len(str(year)) != 4):
         print('Year must be four characters. Exiting.')
         sys.exit()
+
+    # Use helper function to determine the frequency from existing json input file if no -fr is specified
+    fr_list = get_vwc_frequency(station, extension, fr)
+    if len(fr_list) > 1:
+        print("Error: vwc_input can only process one frequency at a time.")
+        print("Please specify a single frequency with -fr or in the json file.")
+        sys.exit()
+    # Get the single frequency from the list
+    fr = fr_list[0]
 
     # Read the JSON file early to get frequency + vwc_ prefixed inputs
     lsp = guts2.read_json_file(station, extension)

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -6,7 +6,7 @@ import sys
 
 from pathlib import Path
 
-from gnssrefl.gps import l2c_l5_list
+from gnssrefl.gps import l2c_l5_list, l1c_list
 from gnssrefl.utils import read_files_in_dir, FileTypes, FileManagement
 import gnssrefl.gnssir_v2 as guts2
 from gnssrefl.phase_functions import get_vwc_frequency
@@ -134,6 +134,10 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     if (fr == 1):
         l1_satellite_list = np.arange(1,33)
         satellite_list = l1_satellite_list
+
+        # Uncomment to use experimental L1C_list function, for filtering to GPS BLock III
+        #satellite_list = l1c_list(year, 365)
+
         apriori_path_f = myxdir + '/input/' + station + '_phaseRH_L1.txt'
     else:
         print('Using L2C satellite list for December 31 on ', year)

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -97,38 +97,14 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
         print('Year must be four characters. Exiting.')
         sys.exit()
 
-    # Use helper function to determine the frequency from existing json input file if no -fr is specified
+    # Use the new helper function to determine the frequency.
     fr_list = get_vwc_frequency(station, extension, fr)
     if len(fr_list) > 1:
         print("Error: vwc_input can only process one frequency at a time.")
         print("Please specify a single frequency with -fr or in the json file.")
         sys.exit()
-    # Get the single frequency from the list
+    # Get the single frequency from the list (vwc command only supports 1 frequency)
     fr = fr_list[0]
-
-    # Read the JSON file early to get frequency + vwc_ prefixed inputs
-    lsp = guts2.read_json_file(station, extension)
-
-    # Determine frequency from command line, JSON, or default to 20
-    if fr is None:
-        if 'freqs' in lsp and lsp['freqs'] is not None:
-            if len(lsp['freqs']) == 1:
-                fr = lsp['freqs'][0]
-                print(f"Frequency read from JSON file: {fr}")
-            else:
-                print("Error: 'freqs' in JSON must be a list with a single value. Exiting.")
-                sys.exit()
-        else:
-            # Default to L2C if not specified anywhere
-            fr = 20
-            print("No frequency specified via command line or JSON. Defaulting to L2C (20).")
-
-    # Warn if not using the standard L2C frequency
-    if fr == 1:
-        print(f"Warning: Only the L2C (-freq 20) is officially supported. L1 (-freq 1) processing is untested and in early development.")
-    elif fr not in [1, 20]:
-        print(f"Error: Frequency {fr} is not supported.")
-        sys.exit()
 
     print('Minimum number of tracks required to save a series ', min_tracks)
     gnssir_results = []
@@ -213,6 +189,8 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     #with open(apriori_path, 'w') as my_file:
         np.savetxt(fout, apriori_array, fmt="%3.0f %6.3f %4.0f %7.2f   %4.0f  %3.0f  %3.0f")
         fout.close()
+
+    lsp = guts2.read_json_file(station, extension)
 
     # new one for minimum normalized amplitude
     lsp['vwc_min_norm_amp'] = 0.5;


### PR DESCRIPTION
# Summary

This PR extends the -extension flag across the vwc_input, phase, and vwc commands. All intermediate and output files for a given run are now saved to a file or subdirectory named after the extension.

The frequency selection logic for these vwc functions has been refactored into a shared helper function (get_vwc_frequency) which reads frequency from the input JSON and manages input priorities: command line > JSON file > default (20).

Additionally, a simple function for identifying L1C transmitting satellites was added (but is currently unused). 

# Workflow

This new structure makes it simple to run parallel analyses for different signals. For example, to compare L1 and L2C results for station p038, a user can now create separate JSON configuration files and run a full workflow for each simultaneously in different terminals (assuming rinex2snr was already run):

```
# --- L1 Analysis ---
gnssir_input p038 2022 -l1 T -extension signal_l1
gnssir p038 1 -doy_end 365 -extension signal_l1
vwc_input p038 2022 -extension signal_l1                      # vwc_input now reads frequency from json
phase p038 2022 1 -doy_end 365 -extension signal_l1
vwc p038 2022 -extension signal_l1

# --- L2C Analysis ---
gnssir_input p038 2022 -l2c T -extension signal_l2c
gnssir p038 1 -doy_end 365 -extension signal_l2c
vwc_input p038 2022 -extension signal_l2c
phase p038 2022 1 -doy_end 365 -extension signal_l2c
vwc p038 2022 -extension signal_l2c
```

The intermediate files are split into subdirectories (in the same way that -extension works in ```gnssir```):

```
refl_code/2022/results
└── p038
    ├── signal_l1
    └── signal_l2c

refl_code/2022/phase
└── p038
    ├── signal_l1
    └── signal_l2c
```

The final outputs are also separated in the Files directory:

```
refl_code/Files/p038/
├── signal_l1/
│   ├── p038_az_phase.png
│   ├── p038_daily_phase.png
│   ├── p038_phase_L1.txt
│   ├── p038_vwc.txt
│   └── raw.phase
├── signal_l1c/
│   ├── p038_az_phase.png
│   ├── p038_daily_phase.png
│   ├── p038_phase_L1.txt
│   ├── p038_vwc.txt
│   └── raw.phase
└── signal_l2c/
    ├── p038_az_phase.png
    ├── p038_daily_phase.png
    ├── p038_phase.txt
    ├── p038_vwc.txt
    └── raw.phase
```
# Example results

Custom plot made from the L1/L2C workflow above + a L1C result using the L1C list function: 

<img width="1600" height="800" alt="commit_example" src="https://github.com/user-attachments/assets/c69d10cf-436f-444c-aa94-4127950fee83" />

# Limitations / Future Work

* The ```p038_phaseRH.txt``` and ```p038_phaseRH_L1.txt``` files/logic is unchanged. So while there might be many extensions, there is currently only support for two RH files (one for each frequency). This could be extended to a RH file for each extension. 
* I have only tested this on my linux system for simple workflows with different freq but otherwise default settings

Please let me know if you have any feedback or suggestions for changes.

Cheers,
George