### PR TITLE
Add L5 support to vwc_input, phase, and vwc commands with FileManagement class refactor

### DIFF
--- a/gnssrefl/gnssir_input.py
+++ b/gnssrefl/gnssir_input.py
@@ -394,16 +394,13 @@ def make_gnssir_input(station: str, lat: float=0, lon: float=0, height: float=0,
     lsp['NReg'] = [nr1, nr2]
     lsp['PkNoise'] = peak2noise
 
-    # where the instructions will be written
-    xdir = os.environ['REFL_CODE']
-    outputdir = xdir + '/input'
-    if not os.path.isdir(outputdir):
-        subprocess.call(['mkdir', outputdir])
-
-    if len(extension) == 0:
-        outputfile = outputdir + '/' + station + '.json'
-    else:
-        outputfile = outputdir + '/' + station + '.' + extension + '.json'
+    # Use FileManagement to get JSON file path with new directory structure
+    from .utils import FileManagement, FileTypes
+    json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
+    outputfile = json_manager.get_file_path()
+    
+    # Ensure directory exists for new structure
+    outputfile.parent.mkdir(parents=True, exist_ok=True)
 
     # 4 was the original default.  Totally up to the user. 
     lsp['polyV'] = polyV # polynomial order for DC removal

--- a/gnssrefl/gnssir_input.py
+++ b/gnssrefl/gnssir_input.py
@@ -7,7 +7,7 @@ import sys
 import gnssrefl.gps as g
 import gnssrefl.gnssir_v2 as guts2
 
-from gnssrefl.utils import str2bool
+from gnssrefl.utils import str2bool, FileManagement, FileTypes
 
 
 def parse_arguments():
@@ -395,7 +395,6 @@ def make_gnssir_input(station: str, lat: float=0, lon: float=0, height: float=0,
     lsp['PkNoise'] = peak2noise
 
     # Use FileManagement to get JSON file path with new directory structure
-    from .utils import FileManagement, FileTypes
     json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
     outputfile = json_manager.get_file_path()
     

--- a/gnssrefl/gnssir_input.py
+++ b/gnssrefl/gnssir_input.py
@@ -395,7 +395,7 @@ def make_gnssir_input(station: str, lat: float=0, lon: float=0, height: float=0,
     lsp['PkNoise'] = peak2noise
 
     # Use FileManagement to get JSON file path with new directory structure
-    json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
+    json_manager = FileManagement(station, 'make_json', extension=extension)
     outputfile = json_manager.get_file_path()
 
     # 4 was the original default.  Totally up to the user. 

--- a/gnssrefl/gnssir_input.py
+++ b/gnssrefl/gnssir_input.py
@@ -29,6 +29,7 @@ def parse_arguments():
     parser.add_argument("-allfreq", default=None, type=str, help="Set to T to include all GNSS signals")
     parser.add_argument("-l1", default=None, type=str, help="Set to T to use only GPS L1")
     parser.add_argument("-l2c", default=None, type=str, help="Set to T to only use GPS L2C")
+    parser.add_argument("-l5", default=None, type=str, help="Set to T to use only GPS L5")
     parser.add_argument("-xyz", default=None, type=str, help="Set to True if using Cartesian coordinates instead of LLH")
     parser.add_argument("-refraction", default=None, type=str, help="Set to False to turn off refraction correction")
     parser.add_argument("-extension", default=None,type=str, help="Provide extension name so you can try different strategies")
@@ -64,7 +65,7 @@ def parse_arguments():
     g.print_version_to_screen()
 
     # convert all expected boolean inputs from strings to booleans
-    boolean_args = ['allfreq', 'l1', 'l2c', 'xyz', 'refraction','subdaily_alt_sigma']
+    boolean_args = ['allfreq', 'l1', 'l2c', 'l5', 'xyz', 'refraction','subdaily_alt_sigma']
     args = str2bool(args, boolean_args)
 
     # only return a dictionary of arguments that were added from the user - all other defaults will be set in code below
@@ -73,7 +74,7 @@ def parse_arguments():
 
 def make_gnssir_input(station: str, lat: float=0, lon: float=0, height: float=0, e1: float = 5.0, e2: float = 25.0,
        h1: float = 0.5, h2: float = 8.0, nr1: float = None, nr2: float = None, peak2noise: float = 2.8, 
-       ampl: float = 5.0, allfreq: bool = False, l1: bool = False, l2c: bool = False, 
+       ampl: float = 5.0, allfreq: bool = False, l1: bool = False, l2c: bool = False, l5: bool = False, 
        xyz: bool = False, refraction: bool = True, extension: str = '', ediff: float=2.0, 
        delTmax: float=75.0, frlist: list=[], azlist2: list=[0,360], ellist : list=[], refr_model : str="1", 
                       apriori_rh: float=None, Hortho : float = None, pele: list=[5,30], polyV: int=4, 
@@ -454,6 +455,9 @@ def make_gnssir_input(station: str, lat: float=0, lon: float=0, height: float=0,
 
     if l2c is True:
         lsp['freqs'] = [20]
+
+    if l5 is True:
+        lsp['freqs'] = [5]
 
     if len(frlist) == 0:
         print('Using standard frequency choices.')

--- a/gnssrefl/gnssir_input.py
+++ b/gnssrefl/gnssir_input.py
@@ -397,9 +397,6 @@ def make_gnssir_input(station: str, lat: float=0, lon: float=0, height: float=0,
     # Use FileManagement to get JSON file path with new directory structure
     json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
     outputfile = json_manager.get_file_path()
-    
-    # Ensure directory exists for new structure
-    outputfile.parent.mkdir(parents=True, exist_ok=True)
 
     # 4 was the original default.  Totally up to the user. 
     lsp['polyV'] = polyV # polynomial order for DC removal

--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -18,6 +18,7 @@ import gnssrefl.gps as g
 import gnssrefl.read_snr_files as snr
 import gnssrefl.refraction as refr
 import gnssrefl.retrieve_rh as r
+from gnssrefl.utils import FileManagement, FileTypes
 
 def gnssir_guts_v2(station,year,doy, snr_type, extension,lsp, debug):
     """
@@ -577,7 +578,6 @@ def read_json_file(station, extension,**kwargs):
     noexit = kwargs.get('noexit',False)
     
     # Use FileManagement to find JSON file with proper fallback
-    from .utils import FileManagement, FileTypes
     json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
     json_path, format_type = json_manager.find_json_file()
     

--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -576,16 +576,18 @@ def read_json_file(station, extension,**kwargs):
     # pick up a new parameter - that will be True for people looking
     # for the json but that aren't upset it does not exist.
     noexit = kwargs.get('noexit',False)
+    silent = kwargs.get('silent',False)
     
     # Use FileManagement to find JSON file with proper fallback
     json_manager = FileManagement(station, 'make_json', extension=extension)
     json_path, format_type = json_manager.find_json_file()
     
     if json_path.exists():
-        if format_type in ['legacy_extension', 'legacy_station']:
-            print(f'Using JSON file (legacy directory): {json_path}')
-        else:
-            print(f'Using JSON file: {json_path}')
+        if not silent:
+            if format_type in ['legacy_extension', 'legacy_station']:
+                print(f'Using JSON file (legacy directory): {json_path}')
+            else:
+                print(f'Using JSON file: {json_path}')
         
         with open(json_path) as f:
             lsp = json.load(f)

--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -184,9 +184,9 @@ def gnssir_guts_v2(station,year,doy, snr_type, extension,lsp, debug):
     # this is for savearcs, txt
     docstring = 'arrays are eangles (degrees), dsnrData is SNR with/DC removed, and sec (seconds of the day),\n'
 
-    xdir = os.environ['REFL_CODE']
-    cdoy = '{:03d}'.format(doy)
-    sdir = xdir + '/' + str(year) + '/arcs/' + station + '/' + cdoy + '/'
+    # Use FileManagement for arcs directory with extension support
+    fm = FileManagement(station, "arcs_directory", year=year, doy=doy, extension=extension)
+    sdir = str(fm.get_directory_path())
     if test_savearcs:
         print('Writing individual arcs (elevation angle, SNR) to ', sdir)
         if not os.path.isdir(sdir):

--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -186,7 +186,7 @@ def gnssir_guts_v2(station,year,doy, snr_type, extension,lsp, debug):
 
     # Use FileManagement for arcs directory with extension support  
     fm = FileManagement(station, "arcs_directory", year=year, doy=doy, extension=extension)
-    sdir = str(fm.get_directory_path(ensure_directory=test_savearcs))
+    sdir = str(fm.get_directory_path(ensure_directory=test_savearcs)) + '/'
     if test_savearcs:
         print('Writing individual arcs (elevation angle, SNR) to ', sdir)
         if not os.path.isdir(sdir):

--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -184,9 +184,9 @@ def gnssir_guts_v2(station,year,doy, snr_type, extension,lsp, debug):
     # this is for savearcs, txt
     docstring = 'arrays are eangles (degrees), dsnrData is SNR with/DC removed, and sec (seconds of the day),\n'
 
-    # Use FileManagement for arcs directory with extension support
+    # Use FileManagement for arcs directory with extension support  
     fm = FileManagement(station, "arcs_directory", year=year, doy=doy, extension=extension)
-    sdir = str(fm.get_directory_path())
+    sdir = str(fm.get_directory_path(ensure_directory=test_savearcs))
     if test_savearcs:
         print('Writing individual arcs (elevation angle, SNR) to ', sdir)
         if not os.path.isdir(sdir):

--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -578,7 +578,7 @@ def read_json_file(station, extension,**kwargs):
     noexit = kwargs.get('noexit',False)
     
     # Use FileManagement to find JSON file with proper fallback
-    json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
+    json_manager = FileManagement(station, 'make_json', extension=extension)
     json_path, format_type = json_manager.find_json_file()
     
     if json_path.exists():

--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -583,9 +583,9 @@ def read_json_file(station, extension,**kwargs):
     
     if json_path.exists():
         if format_type in ['legacy_extension', 'legacy_station']:
-            print(f'Using legacy JSON file: {json_path}')
+            print(f'Using JSON file (legacy directory): {json_path}')
         else:
-            print(f'Using these instructions {json_path}')
+            print(f'Using JSON file: {json_path}')
         
         with open(json_path) as f:
             lsp = json.load(f)

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -577,7 +577,7 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
 
     # read makejson
     station_file = FileManagement(station, 'make_json')
-    json_data = gnssir.read_json_file(station, extension)
+    json_data = gnssir.read_json_file(station, extension, silent=True)
 
     if json_data['lat'] >= 0:
         print('Northern hemisphere summer')
@@ -1265,9 +1265,9 @@ def set_parameters(station, minvalperday,tmin,tmax,min_req_pts_track,fr, year, y
     g.checkFiles(station, '')
     # should not crash if file does not exist...
     if extension is None:
-        lsp = gnssir.read_json_file(station, '',noexit=True)
+        lsp = gnssir.read_json_file(station, '',noexit=True, silent=True)
     else:
-        lsp = gnssir.read_json_file(station, extension,noexit=True)
+        lsp = gnssir.read_json_file(station, extension,noexit=True, silent=True)
 
     # originally this was for command line interface ... 
     remove_bad_tracks = auto_removal # ??

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -425,9 +425,7 @@ def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, scre
 
     else:
         header = "Year DOY Hour   Phase   Nv  Azimuth  Sat  Ampl emin emax  DelT aprioriRH  freq estRH  pk2noise LSPAmp\n(1)  (2)  (3)    (4)   (5)    (6)    (7)  (8)  (9)  (10)  (11)   (12)     (13)  (14)    (15)    (16)"
-        output_path = FileManagement(station, 'phase_file', year, doy).get_file_path()
-        if extension:
-            output_path = output_path.parent / extension / output_path.name
+        output_path = FileManagement(station, 'phase_file', year, doy, extension=extension).get_file_path()
 
         print(f"Saving phase file to: {output_path}")
         with open(output_path, 'w') as my_file:

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -255,9 +255,9 @@ def read_apriori_rh(station, fr, extension=''):
     if apriori_path_f.exists():
         result = np.loadtxt(apriori_path_f, comments='%', ndmin=2)
         if is_legacy:
-            print(f'Using legacy RH file: {apriori_path_f}')
+            print(f'Using RH file (legacy directory): {apriori_path_f}')
         else:
-            print(f'Using: {apriori_path_f}')
+            print(f'Using RH file: {apriori_path_f}')
     else:
         print('Average RH file does not exist')
         sys.exit()

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -253,11 +253,11 @@ def read_apriori_rh(station, fr, extension=''):
     """
     result = []
     file_manager = FileManagement(station, 'apriori_rh_file', frequency=fr, extension=extension)
-    apriori_path_f, is_legacy = file_manager.find_apriori_rh_file()
+    apriori_path_f, format_type = file_manager.find_apriori_rh_file()
 
     if apriori_path_f.exists():
         result = np.loadtxt(apriori_path_f, comments='%', ndmin=2)
-        if is_legacy:
+        if format_type == 'legacy':
             print(f'Using RH file (legacy directory): {apriori_path_f}')
         else:
             print(f'Using RH file: {apriori_path_f}')
@@ -923,7 +923,7 @@ def apriori_file_exist(station, fr, extension=''):
 
     """
     file_manager = FileManagement(station, 'apriori_rh_file', frequency=fr, extension=extension)
-    apriori_path_f, _ = file_manager.find_apriori_rh_file()
+    apriori_path_f, format_type = file_manager.find_apriori_rh_file()
     
     return apriori_path_f.exists() 
 

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -793,7 +793,10 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
     print('>>> VWC results being written to ', vwcfile)
     with open(vwcfile, 'w') as w:
         N = len(nv)
+        freq_map = {1: "L1", 2: "L2C", 20: "L2C", 5: "L5"}
+        freq_name = freq_map.get(fr, f"Frequency {fr}")
         w.write("% Soil Moisture Results for GNSS Station {0:4s} \n".format(station))
+        w.write("% Frequency used: {0} \n".format(freq_name))
         w.write("% {0:s} \n".format('https://github.com/kristinemlarson/gnssrefl'))
         w.write("% FracYr    Year   DOY   VWC Month Day \n")
         for iw in range(0, N):

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -806,7 +806,7 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
                 w.write(f"{fdate:10.4f} {myyear:4.0f} {mydoy:4.0f} {watercontent:8.3f} {mm:3.0f} {dd:3.0f} \n")
 
 
-def write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir):
+def write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir,extension=''):
 
     """
     creates output file for average phase results
@@ -834,6 +834,9 @@ def write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir):
 
     subdir : str
         subdirectory for results
+    
+    extension : str, optional
+        analysis extension for directory organization
 
     Returns
     -------

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -328,8 +328,9 @@ def get_vwc_frequency(station: str, extension: str, fr_cmd: str = None):
     """
     # Handle the 'all' case first, which overrides everything else.
     if fr_cmd == 'all':
-        print("Processing all supported frequencies: L1 (1) and L2C (20).")
-        return [1, 20]
+        print("Processing all supported frequencies: L1 (1), L2C (20), and L5 (5).")
+        print("Note: L1 and L5 are experimental - only L2C is officially supported.")
+        return [1, 20, 5]
 
     final_fr = None
     # Use command line frequency if provided (and it's not 'all')
@@ -356,10 +357,13 @@ def get_vwc_frequency(station: str, extension: str, fr_cmd: str = None):
             print("No frequency specified. Defaulting to L2C (20).")
 
     # Warn if not using the standard L2C frequency
-    if final_fr not in [1, 20]:
-        print(f"Warning: Only frequencies 1 (L1) and 20 (L2C) are officially supported.")
-    elif final_fr != 20:
-        print(f"Warning: Analyzing frequency L1 ({final_fr}). The standard is L2C (20).")
+    if final_fr not in [1, 20, 5]:
+        print(f"Error: Frequency {final_fr} is not supported. Supported frequencies: 1 (L1), 20 (L2C), 5 (L5).")
+        sys.exit()
+    elif final_fr == 1:
+        print(f"Warning: Using L1 frequency ({final_fr}) - EXPERIMENTAL. Only L2C (20) is officially supported.")
+    elif final_fr == 5:
+        print(f"Warning: Using L5 frequency ({final_fr}) - EXPERIMENTAL. Only L2C (20) is officially supported.")
 
     # Always return a list
     return [final_fr]

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -249,7 +249,7 @@ def read_apriori_rh(station, fr, extension=''):
         column 7 is maximum azimuth degrees for the quadrant
     """
     result = []
-    file_manager = FileManagement(station, FileTypes.apriori_rh_file, frequency=fr, extension=extension)
+    file_manager = FileManagement(station, 'apriori_rh_file', frequency=fr, extension=extension)
     apriori_path_f, is_legacy = file_manager.find_apriori_rh_file()
 
     if apriori_path_f.exists():
@@ -424,7 +424,7 @@ def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, scre
 
     else:
         header = "Year DOY Hour   Phase   Nv  Azimuth  Sat  Ampl emin emax  DelT aprioriRH  freq estRH  pk2noise LSPAmp\n(1)  (2)  (3)    (4)   (5)    (6)    (7)  (8)  (9)  (10)  (11)   (12)     (13)  (14)    (15)    (16)"
-        output_path = FileManagement(station, FileTypes.phase_file, year, doy).get_file_path()
+        output_path = FileManagement(station, 'phase_file', year, doy).get_file_path()
         if extension:
             output_path = output_path.parent / extension / output_path.name
 
@@ -577,7 +577,7 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
         year_end = year
 
     # read makejson
-    station_file = FileManagement(station, FileTypes.make_json)
+    station_file = FileManagement(station, 'make_json')
     json_data = gnssir.read_json_file(station, extension)
 
     if json_data['lat'] >= 0:
@@ -604,7 +604,7 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
 
 
     # Use FileManagement for consistent phase file paths
-    file_manager = FileManagement(station, FileTypes.daily_avg_phase_results, extension=extension)
+    file_manager = FileManagement(station, 'daily_avg_phase_results', extension=extension)
     fileout = file_manager.get_file_path()
     
     # Handle L1 frequency naming convention
@@ -785,7 +785,7 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
         plt.show()
 
     # Use FileManagement with extension support for consistent directory structure
-    file_manager = FileManagement(station, FileTypes.volumetric_water_content, extension=extension)
+    file_manager = FileManagement(station, 'volumetric_water_content', extension=extension)
     vwcfile = file_manager.get_file_path()
     print('>>> VWC results being written to ', vwcfile)
     with open(vwcfile, 'w') as w:
@@ -857,7 +857,7 @@ def write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir):
     tv = np.empty(shape=[0, 4])
 
     # Use FileManagement for consistent phase file paths
-    file_manager = FileManagement(station, FileTypes.daily_avg_phase_results, extension=extension)
+    file_manager = FileManagement(station, 'daily_avg_phase_results', extension=extension)
     fileout = file_manager.get_file_path()
     
     # Handle L1 frequency naming convention
@@ -908,7 +908,7 @@ def apriori_file_exist(station, fr, extension=''):
     boolean as to whether the apriori file exists
 
     """
-    file_manager = FileManagement(station, FileTypes.apriori_rh_file, frequency=fr, extension=extension)
+    file_manager = FileManagement(station, 'apriori_rh_file', frequency=fr, extension=extension)
     apriori_path_f, _ = file_manager.find_apriori_rh_file()
     
     return apriori_path_f.exists() 
@@ -1093,7 +1093,7 @@ def load_avg_phase(station,fr):
     avg_exist = False
 
     # Use FileManagement for consistent phase file paths
-    file_manager = FileManagement(station, FileTypes.daily_avg_phase_results)
+    file_manager = FileManagement(station, 'daily_avg_phase_results')
     xfile = file_manager.get_file_path()
     
     # Handle L1 frequency naming convention

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -68,7 +68,7 @@ def daily_phase_plot(station, fr,datetime_dates, tv,xdir,subdir,hires_figs):
         whether you want eps instead of png files
 
     """
-    outdir = xdir + '/Files/' + subdir
+    outdir = Path(xdir) / 'Files' / subdir
     plt.figure(figsize=(10, 6))
     plt.plot(datetime_dates, tv[:, 2], 'b-')
     plt.ylabel('phase (degrees)')
@@ -126,7 +126,8 @@ def make_snow_filter(station, medfilter, ReqTracks, year1, year2):
     """
     snowmask_exists = False
     myxdir = os.environ['REFL_CODE']
-    snowfile = myxdir + '/Files/' + station + '/snowmask_' + station + '.txt' 
+    # Use consistent path structure for snow mask file
+    snowfile = Path(myxdir) / 'Files' / station / f'snowmask_{station}.txt' 
     if os.path.exists(snowfile):
         print('Using existing snow mask file, ', snowfile)
         snowmask_exists = True
@@ -139,7 +140,7 @@ def make_snow_filter(station, medfilter, ReqTracks, year1, year2):
     # writes out a daily average file. woudl be better if it returned the values, but this works
     da.daily_avg(station, medfilter, ReqTracks, txtfile, pltit,
               extension, year1, year2, fr, csv) 
-    avgf = myxdir + '/Files/' + station + '/' + txtfile
+    avgf = Path(myxdir) / 'Files' / station / txtfile
     print('Looking in ', avgf)
     x = np.loadtxt(avgf, comments='%')
     # delete the file!
@@ -764,7 +765,7 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
     ax.grid()
     plt.gcf().autofmt_xdate()
 
-    outdir = f'{xdir}/Files/{subdir}'
+    outdir = Path(xdir) / 'Files' / subdir
 
     if hires_figs:
         plot_path = f'{outdir}/{station}_phase_vwc_result.eps'
@@ -1053,7 +1054,7 @@ def help_debug(rt,xdir, station):
         name of the station
 
     """
-    fname = xdir + '/Files/' + station +'/tmp.' + station
+    fname = Path(xdir) / 'Files' / station / f'tmp.{station}'
     # don't have a priori rh values at this point
     rhtrack = 0
     #if True:
@@ -1144,7 +1145,7 @@ def load_sat_phase(station, year, year_end, freq, extension = ''):
     print('Requested frequency: ', freq)
     dataexist = False
     xdir = os.environ['REFL_CODE']
-    xfile = xdir + '/input/override/' + station + '_vwc' 
+    xfile = Path(xdir) / 'input' / 'override' / f'{station}_vwc' 
     found_override = False
     # not implementing this yet
     if os.path.exists(xfile):

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -421,7 +421,7 @@ def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, scre
     # noise region - hardwired for normal sites ~ 2-3 meters tall
     noise_region = [0.5, 8]
 
-    l2c_list, l5_sat = g.l2c_l5_list(year,doy)
+    l2c_list, l5_list = g.l2c_l5_list(year,doy)
 
     if not snrexist:
         print('No SNR file on this day.')
@@ -463,6 +463,11 @@ def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, scre
                     if (freq == 20) and (sat_number not in l2c_list) :
                         if screenstats: 
                             print('Asked for L2C but this is not L2C transmitting on this day: ', int(sat_number))
+                        compute_lsp = False
+                    
+                    if (freq == 5) and (sat_number not in l5_list):
+                        if screenstats: 
+                            print('Asked for L5 but this is not L5 transmitting on this day: ', int(sat_number))
                         compute_lsp = False
 
                     if screenstats:

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -427,7 +427,6 @@ def phase_tracks(station, year, doy, snr_type, fr_list, e1, e2, pele, plot, scre
         output_path = FileManagement(station, FileTypes.phase_file, year, doy).get_file_path()
         if extension:
             output_path = output_path.parent / extension / output_path.name
-            output_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure the new subdirectory exists
 
         print(f"Saving phase file to: {output_path}")
         with open(output_path, 'w') as my_file:
@@ -578,7 +577,7 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
         year_end = year
 
     # read makejson
-    station_file = FileManagement(station, 'make_json')
+    station_file = FileManagement(station, FileTypes.make_json)
     json_data = gnssir.read_json_file(station, extension)
 
     if json_data['lat'] >= 0:
@@ -604,12 +603,13 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
     myxdir = os.environ['REFL_CODE']
 
 
-    # begging for a function ...
-    # overriding Kelly's code for now
+    # Use FileManagement for consistent phase file paths
+    file_manager = FileManagement(station, FileTypes.daily_avg_phase_results, extension=extension)
+    fileout = file_manager.get_file_path()
+    
+    # Handle L1 frequency naming convention
     if (fr == 1):
-        fileout = myxdir + '/Files/' + subdir + '/' + station + '_phase_L1.txt'
-    else:
-        fileout = myxdir + '/Files/' + subdir + '/' + station + '_phase.txt'
+        fileout = fileout.parent / f"{station}_phase_L1.txt"
     print(subdir)
 
     if os.path.exists(fileout):
@@ -784,9 +784,9 @@ def convert_phase(station, year, year_end=None, plt2screen=True,fr=20,tmin=0.05,
     if plt2screen:
         plt.show()
 
-    vwcfile = FileManagement(station, FileTypes.volumetric_water_content).get_file_path()
-
-    vwcfile = f'{outdir}/{station}_vwc.txt'
+    # Use FileManagement with extension support for consistent directory structure
+    file_manager = FileManagement(station, FileTypes.volumetric_water_content, extension=extension)
+    vwcfile = file_manager.get_file_path()
     print('>>> VWC results being written to ', vwcfile)
     with open(vwcfile, 'w') as w:
         N = len(nv)
@@ -856,11 +856,13 @@ def write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir):
 
     tv = np.empty(shape=[0, 4])
 
-    # ultimately would like to use kelly's code here
+    # Use FileManagement for consistent phase file paths
+    file_manager = FileManagement(station, FileTypes.daily_avg_phase_results, extension=extension)
+    fileout = file_manager.get_file_path()
+    
+    # Handle L1 frequency naming convention
     if (fr == 1):
-        fileout = myxdir + '/Files/'  + subdir + '/' + station + '_phase_L1.txt'
-    else:
-        fileout = myxdir + '/Files/' + subdir + '/' + station + '_phase.txt'
+        fileout = fileout.parent / f"{station}_phase_L1.txt"
 
     print('Daily averaged phases will be written to : ', fileout)
     with open(fileout, 'w') as fout:
@@ -969,7 +971,6 @@ def load_phase_filter_out_snow(station, year1, year2, fr, snowmask, extension = 
         output_dir = output_dir / extension
 
     # Ensure the directory exists before trying to save to it
-    output_dir.mkdir(parents=True, exist_ok=True)
     fname = output_dir / 'raw.phase'
 
     dataexist, results = load_sat_phase(station, year1,year2, fr, extension)
@@ -1091,10 +1092,13 @@ def load_avg_phase(station,fr):
     avg_phase = []
     avg_exist = False
 
+    # Use FileManagement for consistent phase file paths
+    file_manager = FileManagement(station, FileTypes.daily_avg_phase_results)
+    xfile = file_manager.get_file_path()
+    
+    # Handle L1 frequency naming convention
     if fr == 1:
-        xfile = f'{xdir}/Files/{station}/{station}_phase_L1.txt'
-    else:
-        xfile = f'{xdir}/Files/{station}/{station}_phase.txt'
+        xfile = xfile.parent / f"{station}_phase_L1.txt"
 
     if os.path.exists(xfile):
         result = np.loadtxt(xfile, comments='%')

--- a/gnssrefl/phase_functions.py
+++ b/gnssrefl/phase_functions.py
@@ -74,6 +74,8 @@ def daily_phase_plot(station, fr,datetime_dates, tv,xdir,subdir,hires_figs):
     plt.ylabel('phase (degrees)')
     if fr == 1:
         plt.title(f"Daily L1 Phase Results: {station.upper()}")
+    elif fr == 5:
+        plt.title(f"Daily L5 Phase Results: {station.upper()}")
     else:
         plt.title(f"Daily L2C Phase Results: {station.upper()}")
     plt.grid()
@@ -303,6 +305,8 @@ def test_func_new(x, a, b, rh_apriori,freq):
     """
     if (freq == 20) or (freq == 2):
         freq_least_squares = 2*np.pi*2*rh_apriori/g.constants.wL2
+    elif freq == 5:
+        freq_least_squares = 2*np.pi*2*rh_apriori/g.constants.wL5
     else:
         freq_least_squares = 2*np.pi*2*rh_apriori/g.constants.wL1
 

--- a/gnssrefl/quickPhase.py
+++ b/gnssrefl/quickPhase.py
@@ -106,7 +106,7 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
 
     # Check that an apriori file exists for each requested frequency.
     for f in fr_list:
-        ex = qp.apriori_file_exist(station, f)
+        ex = qp.apriori_file_exist(station, f, extension)
         if not ex:
             print(f'No apriori RH file exists for frequency {f}. Please run vwc_input.')
             sys.exit()

--- a/gnssrefl/quickPhase.py
+++ b/gnssrefl/quickPhase.py
@@ -13,7 +13,7 @@ def parse_arguments():
     parser.add_argument("year", help="year", type=int)
     parser.add_argument("doy", help="doy", type=int)
     parser.add_argument("-snr", default=None, help="snr file ending", type=int)
-    parser.add_argument("-fr", default=None, help="frequency (e.g. 1, 20, or 'all'). If not set, reads from json.", type=str)
+    parser.add_argument("-fr", default=None, help="frequency: 1 (L1), 20 (L2C), 5 (L5), or 'all'. Only L2C officially supported.", type=str)
     parser.add_argument("-doy_end", "-doy_end", default=None, type=int, help="doy end")
     parser.add_argument("-year_end", "-year_end", default=None, type=int, help="year end")
     parser.add_argument("-extension", default='', help="analysis extension for json file", type=str)

--- a/gnssrefl/retrieve_rh.py
+++ b/gnssrefl/retrieve_rh.py
@@ -47,7 +47,7 @@ def retrieve_rh(station,year,doy,extension, midnite, lsp, snrD, outD, screenstat
     # Only create directory if savearcs is enabled
     test_savearcs = lsp.get('savearcs', False)
     fm = FileManagement(station, "arcs_directory", year=year, doy=doy, extension=extension)
-    sdir = str(fm.get_directory_path(ensure_directory=test_savearcs))
+    sdir = str(fm.get_directory_path(ensure_directory=test_savearcs)) + '/'
     
     all_lsp = [] # variable to save the results so you can sort them
 

--- a/gnssrefl/retrieve_rh.py
+++ b/gnssrefl/retrieve_rh.py
@@ -6,6 +6,7 @@ import sys
 
 import gnssrefl.gnssir_v2 as guts
 import gnssrefl.gps as g
+from gnssrefl.utils import FileManagement
 
 def retrieve_rh(station,year,doy,extension, midnite, lsp, snrD, outD, screenstats, irefr,logid,logfilename):
     """
@@ -42,11 +43,11 @@ def retrieve_rh(station,year,doy,extension, midnite, lsp, snrD, outD, screenstat
     """
     docstring = 'arrays are eangles (degrees), dsnrData is SNR with/DC removed, and sec (seconds of the day),\n'
 
-    xdir = os.environ['REFL_CODE']
+    # Use FileManagement for arcs directory with extension support
+    fm = FileManagement(station, "arcs_directory", year=year, doy=doy, extension=extension)
+    sdir = str(fm.get_directory_path())
+    
     all_lsp = [] # variable to save the results so you can sort them
-
-    cdoy = '{:03d}'.format(doy)
-    sdir = xdir + '/' + str(year) + '/arcs/' + station + '/' + cdoy + '/'
 
     d = g.doy2ymd(year,doy); month = d.month; day = d.day
 

--- a/gnssrefl/retrieve_rh.py
+++ b/gnssrefl/retrieve_rh.py
@@ -44,8 +44,10 @@ def retrieve_rh(station,year,doy,extension, midnite, lsp, snrD, outD, screenstat
     docstring = 'arrays are eangles (degrees), dsnrData is SNR with/DC removed, and sec (seconds of the day),\n'
 
     # Use FileManagement for arcs directory with extension support
+    # Only create directory if savearcs is enabled
+    test_savearcs = lsp.get('savearcs', False)
     fm = FileManagement(station, "arcs_directory", year=year, doy=doy, extension=extension)
-    sdir = str(fm.get_directory_path())
+    sdir = str(fm.get_directory_path(ensure_directory=test_savearcs))
     
     all_lsp = [] # variable to save the results so you can sort them
 

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -67,9 +67,13 @@ class FileManagement:
     Optional parameters are year, doy, and file_not_found_ok.
     """
 
-    def __init__(self, station, file_type: FileTypes, year: int = None, doy: int = None, file_not_found_ok: bool = False, frequency: int = None, extension: str = ''):
+    def __init__(self, station, file_type, year: int = None, doy: int = None, file_not_found_ok: bool = False, frequency: int = None, extension: str = ''):
         self.station = station
-        self.file_type: FileTypes = file_type
+        # Convert string to FileTypes enum if needed for better usability
+        if isinstance(file_type, str):
+            self.file_type = getattr(FileTypes, file_type)
+        else:
+            self.file_type = file_type
         self.year = year
         self.doy = doy
         self.file_not_found_ok = file_not_found_ok

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -108,7 +108,10 @@ class FileManagement:
                      }
 
             if self.year and self.doy:
-                files[FileTypes.phase_file] = self.xdir / str(self.year) / 'phase' / str(self.station) / f'{self.doy:03d}.txt'
+                phase_path = self.xdir / str(self.year) / 'phase' / str(self.station)
+                if self.extension:
+                    phase_path = phase_path / self.extension
+                files[FileTypes.phase_file] = phase_path / f'{self.doy:03d}.txt'
 
             file_path = files[self.file_type]
             

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -158,37 +158,36 @@ class FileManagement:
         Find apriori RH file with backwards compatibility fallback.
         
         Search order:
-        1. New format: {station}_phaseRH_L{freq}[_{extension}].txt
-        2. Legacy fallback: {station}_phaseRH[_L1].txt (L2 default, L1 explicit)
+        1. New format: input/{station}/[{extension}/]{station}_phaseRH_L{freq}.txt
+        2. Legacy fallback: input/{station}_phaseRH[_L1|_L5].txt (L2 has no suffix)
         
-        Returns: (Path, bool) - (file_path, is_legacy_format)
+        Returns:
+            tuple: (Path, str) - (file_path, format_type)
+                format_type: 'new_format', 'legacy'
         """
         # Try new format first
         new_path = self._get_apriori_rh_path()
         if new_path.exists():
-            return new_path, False
+            return new_path, 'new_format'
         
-        # Try legacy format fallback
-        base_dir = self.xdir / "input"  # Legacy files are always in root input/
+        # Try legacy format fallback in root input/ directory
+        base_dir = self.xdir / "input"
         
         if self.frequency == 1:
-            # L1 legacy format
             legacy_path = base_dir / f"{self.station}_phaseRH_L1.txt"
         elif self.frequency == 20 or self.frequency is None:
-            # L2C/L2 legacy format (no frequency suffix for backwards compatibility)
+            # L2C legacy has no frequency suffix for backwards compatibility
             legacy_path = base_dir / f"{self.station}_phaseRH.txt"
         elif self.frequency == 5:
-            # L5 legacy format
             legacy_path = base_dir / f"{self.station}_phaseRH_L5.txt"
         else:
-            # Other frequencies
             legacy_path = base_dir / f"{self.station}_phaseRH_L{self.frequency}.txt"
         
         if legacy_path.exists():
-            return legacy_path, True
+            return legacy_path, 'legacy'
         
-        # Return new format path even if it doesn't exist (for writing new files)
-        return new_path, False
+        # Return new format path for writing new files
+        return new_path, 'new_format'
 
     def _get_json_path(self):
         """

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -78,10 +78,19 @@ class FileManagement:
 
         self.xdir = Path(os.environ["REFL_CODE"])
 
-    def get_file_path(self):
+    def get_file_path(self, ensure_directory=True):
         """
         Get the path of a specific file from the FileTypes class.
-        Returns file paths requested as a string
+        
+        Parameters
+        ----------
+        ensure_directory : bool, optional
+            If True, creates the parent directory if it doesn't exist. Default is True.
+            
+        Returns
+        -------
+        Path
+            File path requested as a Path object
         """
         if self.file_type in FileTypes.__dict__.keys():
             files = {FileTypes.apriori_rh_file: self._get_apriori_rh_path(),
@@ -93,7 +102,13 @@ class FileManagement:
             if self.year and self.doy:
                 files[FileTypes.phase_file] = self.xdir / str(self.year) / 'phase' / str(self.station) / f'{self.doy:03d}.txt'
 
-            return files[self.file_type]
+            file_path = files[self.file_type]
+            
+            # Create directory if requested
+            if ensure_directory:
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                
+            return file_path
         else:
             raise ValueError("The file type you requested does not exist")
 

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -9,6 +9,24 @@ from typing import get_type_hints
 from pathlib import Path
 
 
+def frequency_to_name(freq):
+    """
+    Convert frequency number to standard name.
+    
+    Parameters
+    ----------
+    freq : int
+        Frequency number
+        
+    Returns
+    -------
+    str
+        Frequency name (L1, L2C, L5) or Unknown for unsupported frequencies
+    """
+    freq_map = {1: 'L1', 20: 'L2C', 5: 'L5'}
+    return freq_map.get(freq, f'Unknown({freq})')
+
+
 def validate_input_datatypes(obj, **kwargs):
     hints = get_type_hints(obj)
 

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -9,24 +9,6 @@ from typing import get_type_hints
 from pathlib import Path
 
 
-def frequency_to_name(freq):
-    """
-    Convert frequency number to standard name.
-    
-    Parameters
-    ----------
-    freq : int
-        Frequency number
-        
-    Returns
-    -------
-    str
-        Frequency name (L1, L2C, L5) or Unknown for unsupported frequencies
-    """
-    freq_map = {1: 'L1', 20: 'L2C', 5: 'L5'}
-    return freq_map.get(freq, f'Unknown({freq})')
-
-
 def validate_input_datatypes(obj, **kwargs):
     hints = get_type_hints(obj)
 

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -81,6 +81,12 @@ class FileManagement:
         self.year = year
         self.doy = doy
         self.file_not_found_ok = file_not_found_ok
+        # Validate frequency parameter
+        if frequency is not None:
+            VALID_FREQUENCIES = [1, 5, 20]
+            if frequency not in VALID_FREQUENCIES:
+                raise ValueError(f"Invalid frequency {frequency}. Valid frequencies: {VALID_FREQUENCIES}")
+        
         self.frequency = frequency
         self.extension = extension
 
@@ -102,7 +108,7 @@ class FileManagement:
         Path
             File path requested as a Path object
         """
-        if self.file_type in FileTypes.__dict__.keys():
+        if isinstance(self.file_type, FileTypes):
             files = {FileTypes.apriori_rh_file: self._get_apriori_rh_path(),
                      FileTypes.daily_avg_phase_results: self._get_daily_avg_phase_path(),
                      FileTypes.make_json: self._get_json_path(),

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -69,8 +69,12 @@ class FileManagement:
 
     def __init__(self, station, file_type, year: int = None, doy: int = None, file_not_found_ok: bool = False, frequency: int = None, extension: str = ''):
         self.station = station
+        
         # Convert string to FileTypes enum if needed for better usability
         if isinstance(file_type, str):
+            if not hasattr(FileTypes, file_type):
+                valid_types = [attr for attr in dir(FileTypes) if not attr.startswith('_')]
+                raise ValueError(f"Unknown file type: '{file_type}'. Valid types: {valid_types}")
             self.file_type = getattr(FileTypes, file_type)
         else:
             self.file_type = file_type

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -140,17 +140,16 @@ class FileManagement:
         if self.extension:
             base_dir = base_dir / self.extension
         
-        # Generate new format filename
+        # Generate clean filename (extension handled by directory structure)
         if self.frequency is None:
             # Default to L2 if no frequency specified
             freq_suffix = "L2"
+        elif self.frequency == 20:
+            freq_suffix = "L2"  # Map L2C (20) to clean L2 naming
         else:
             freq_suffix = f"L{self.frequency}"
         
-        if self.extension:
-            filename = f"{self.station}_phaseRH_{freq_suffix}_{self.extension}.txt"
-        else:
-            filename = f"{self.station}_phaseRH_{freq_suffix}.txt"
+        filename = f"{self.station}_phaseRH_{freq_suffix}.txt"
         
         return base_dir / filename
 
@@ -175,9 +174,15 @@ class FileManagement:
         if self.frequency == 1:
             # L1 legacy format
             legacy_path = base_dir / f"{self.station}_phaseRH_L1.txt"
-        else:
-            # L2 legacy format (no frequency suffix)
+        elif self.frequency == 20 or self.frequency is None:
+            # L2C/L2 legacy format (no frequency suffix for backwards compatibility)
             legacy_path = base_dir / f"{self.station}_phaseRH.txt"
+        elif self.frequency == 5:
+            # L5 legacy format
+            legacy_path = base_dir / f"{self.station}_phaseRH_L5.txt"
+        else:
+            # Other frequencies
+            legacy_path = base_dir / f"{self.station}_phaseRH_L{self.frequency}.txt"
         
         if legacy_path.exists():
             return legacy_path, True

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -84,6 +84,8 @@ class FileManagement:
         self.frequency = frequency
         self.extension = extension
 
+        if "REFL_CODE" not in os.environ:
+            raise EnvironmentError("REFL_CODE environment variable not set")
         self.xdir = Path(os.environ["REFL_CODE"])
 
     def get_file_path(self, ensure_directory=True):

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -125,18 +125,16 @@ class FileManagement:
 
     def _get_apriori_rh_path(self):
         """
-        Generate backwards-compatible apriori RH file paths with frequency and extension support.
+        Generate apriori RH file paths with station/extension directory structure.
         
-        New naming convention:
-        - No extension: {station}_phaseRH_L{freq}.txt  
-        - With extension: {station}_phaseRH_L{freq}_{extension}.txt
+        Directory structure:
+        - No extension: input/{station}/{station}_phaseRH_L{freq}.txt
+        - With extension: input/{station}/{extension}/{station}_phaseRH_L{freq}.txt
         
-        Fallback for legacy files:
-        - L2 legacy: {station}_phaseRH.txt (no L2 suffix)
-        - L1 legacy: {station}_phaseRH_L1.txt
+        Fallback for legacy files in input/ root directory.
         """
-        # Determine base directory
-        base_dir = self.xdir / "input"
+        # Determine base directory with station/extension structure
+        base_dir = self.xdir / "input" / self.station
         if self.extension:
             base_dir = base_dir / self.extension
         

--- a/gnssrefl/utils.py
+++ b/gnssrefl/utils.py
@@ -85,9 +85,9 @@ class FileManagement:
         """
         if self.file_type in FileTypes.__dict__.keys():
             files = {FileTypes.apriori_rh_file: self._get_apriori_rh_path(),
-                     FileTypes.daily_avg_phase_results: self.xdir / "Files" / f"{self.station}_phase.txt",
+                     FileTypes.daily_avg_phase_results: self._get_daily_avg_phase_path(),
                      FileTypes.make_json: self._get_json_path(),
-                     FileTypes.volumetric_water_content: self.xdir / "Files" / f"{self.station}_vwc.txt"
+                     FileTypes.volumetric_water_content: self._get_volumetric_water_content_path()
                      }
 
             if self.year and self.doy:
@@ -211,6 +211,112 @@ class FileManagement:
         
         # Return new format path for writing
         return self._get_json_path(), 'new_format'
+
+    def _get_daily_avg_phase_path(self):
+        """
+        Generate phase file paths with station/extension directory structure.
+        
+        New directory structure:
+        - No extension: Files/{station}/{station}_phase.txt
+        - With extension: Files/{station}/{extension}/{station}_phase.txt
+        """
+        if self.extension:
+            phase_dir = self.xdir / "Files" / self.station / self.extension
+            return phase_dir / f"{self.station}_phase.txt"
+        else:
+            phase_dir = self.xdir / "Files" / self.station
+            return phase_dir / f"{self.station}_phase.txt"
+
+    def find_daily_avg_phase_file(self):
+        """
+        Find daily average phase file with backwards compatibility fallback.
+        
+        Search order:
+        - No extension: 
+          1. Files/{station}/{station}_phase.txt (new format)
+          2. Files/{station}_phase.txt (legacy fallback)
+        - With extension:
+          1. Files/{station}/{extension}/{station}_phase.txt (new format)  
+          2. Files/{station}_phase.txt (legacy fallback - no extension separation in legacy)
+        
+        Returns: (Path, str) - (file_path, format_type)
+        """
+        if self.extension:
+            # Extension specified: try new extension format first
+            extension_dir_path = self.xdir / "Files" / self.station / self.extension / f"{self.station}_phase.txt"
+            if extension_dir_path.exists():
+                return extension_dir_path, 'extension_dir'
+            
+            # Fall back to legacy format (no extension distinction in legacy)
+            legacy_path = self.xdir / "Files" / f"{self.station}_phase.txt"
+            if legacy_path.exists():
+                return legacy_path, 'legacy'
+        else:
+            # No extension: try new station format first
+            station_dir_path = self.xdir / "Files" / self.station / f"{self.station}_phase.txt"
+            if station_dir_path.exists():
+                return station_dir_path, 'station_dir'
+            
+            # Fall back to legacy format
+            legacy_path = self.xdir / "Files" / f"{self.station}_phase.txt"
+            if legacy_path.exists():
+                return legacy_path, 'legacy'
+        
+        # Return new format path for writing
+        return self._get_daily_avg_phase_path(), 'new_format'
+
+    def _get_volumetric_water_content_path(self):
+        """
+        Generate volumetric water content file paths with station/extension directory structure.
+        
+        New directory structure:
+        - No extension: Files/{station}/{station}_vwc.txt
+        - With extension: Files/{station}/{extension}/{station}_vwc.txt
+        """
+        if self.extension:
+            vwc_dir = self.xdir / "Files" / self.station / self.extension
+            return vwc_dir / f"{self.station}_vwc.txt"
+        else:
+            vwc_dir = self.xdir / "Files" / self.station
+            return vwc_dir / f"{self.station}_vwc.txt"
+
+    def find_volumetric_water_content_file(self):
+        """
+        Find volumetric water content file with backwards compatibility fallback.
+        
+        Search order:
+        - No extension: 
+          1. Files/{station}/{station}_vwc.txt (new format)
+          2. Files/{station}_vwc.txt (legacy fallback)
+        - With extension:
+          1. Files/{station}/{extension}/{station}_vwc.txt (new format)  
+          2. Files/{station}_vwc.txt (legacy fallback - no extension separation in legacy)
+        
+        Returns: (Path, str) - (file_path, format_type)
+        """
+        if self.extension:
+            # Extension specified: try new extension format first
+            extension_dir_path = self.xdir / "Files" / self.station / self.extension / f"{self.station}_vwc.txt"
+            if extension_dir_path.exists():
+                return extension_dir_path, 'extension_dir'
+            
+            # Fall back to legacy format (no extension distinction in legacy)
+            legacy_path = self.xdir / "Files" / f"{self.station}_vwc.txt"
+            if legacy_path.exists():
+                return legacy_path, 'legacy'
+        else:
+            # No extension: try new station format first
+            station_dir_path = self.xdir / "Files" / self.station / f"{self.station}_vwc.txt"
+            if station_dir_path.exists():
+                return station_dir_path, 'station_dir'
+            
+            # Fall back to legacy format
+            legacy_path = self.xdir / "Files" / f"{self.station}_vwc.txt"
+            if legacy_path.exists():
+                return legacy_path, 'legacy'
+        
+        # Return new format path for writing
+        return self._get_volumetric_water_content_path(), 'new_format'
 
     def read_file(self, transpose=False, **kwargs):
         """

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -233,8 +233,8 @@ def vwc(station: str, year: int, year_end: int = None, fr: str = None, plt: bool
     # checking each geographic quadrant
     k4 = 1
     # two list of tracks - lets you compare an old run with a new run as a form of QC
-    newlist = station + '_tmp.txt'
-    oldlist = xdir + '/input/' + station + '_phaseRH.txt'
+    newlist = f'{station}_tmp.txt'
+    oldlist = Path(xdir) / 'input' / f'{station}_phaseRH.txt'
 
     ftmp = open(newlist,'w+')
     ftmp.write("{0:s} \n".format( '% station ' + station) )

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -437,7 +437,7 @@ def vwc(station: str, year: int, year_end: int = None, fr: str = None, plt: bool
         sys.exit()
     else:
         # write out daily phase values
-        tv = qp.write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir)
+        tv = qp.write_avg_phase(station, phase, fr,year,year_end,minvalperday,vxyz,subdir,extension)
         print('Number of daily phase measurements ', len(tv))
         if len(tv) < 1:
             print('No results - perhaps minvalperday or min_req_pts_track are too stringent')

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -14,7 +14,7 @@ import gnssrefl.phase_functions as qp
 import gnssrefl.gps as g
 import gnssrefl.gnssir_v2 as gnssir
 
-from gnssrefl.utils import str2bool, read_files_in_dir
+from gnssrefl.utils import str2bool, read_files_in_dir, FileManagement
 
 xdir = os.environ['REFL_CODE']
 
@@ -234,7 +234,8 @@ def vwc(station: str, year: int, year_end: int = None, fr: str = None, plt: bool
     k4 = 1
     # two list of tracks - lets you compare an old run with a new run as a form of QC
     newlist = f'{station}_tmp.txt'
-    oldlist = Path(xdir) / 'input' / f'{station}_phaseRH.txt'
+    file_manager = FileManagement(station, 'apriori_rh_file', frequency=fr, extension=extension)
+    oldlist = file_manager.get_file_path()
 
     ftmp = open(newlist,'w+')
     ftmp.write("{0:s} \n".format( '% station ' + station) )

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -185,7 +185,7 @@ def vwc(station: str, year: int, year_end: int = None, fr: str = None, plt: bool
     
     # pick up the tracks you will use to compute phase.  THis was previously
     # created by vwc_input ...
-    tracks = qp.read_apriori_rh(station,freq)
+    tracks = qp.read_apriori_rh(station, freq, extension)
     nr = len(tracks[:,1])
 
     if (minvalperday > nr ):

--- a/gnssrefl/vwc_cl.py
+++ b/gnssrefl/vwc_cl.py
@@ -24,7 +24,7 @@ def parse_arguments():
     parser.add_argument("station", help="station", type=str)
     parser.add_argument("year", help="year", type=int)
     parser.add_argument("-year_end", default=None, help="year_end", type=int)
-    parser.add_argument("-fr", help="frequency", type=str)
+    parser.add_argument("-fr", help="frequency: 1 (L1), 20 (L2C), 5 (L5). Only L2C officially supported.", type=str)
     parser.add_argument("-plt", default=None, type=str, help="boolean for plotting to screen")
     parser.add_argument("-screenstats", default=None, type=str, help="boolean for plotting statistics to screen")
     parser.add_argument("-min_req_pts_track", default=None, type=int, help="min number of points for a track to be kept. Default is 100")

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -173,9 +173,6 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     # Use FileManagement with frequency and extension support
     file_manager = FileManagement(station, FileTypes.apriori_rh_file, frequency=fr, extension=extension)
     apriori_path_f = file_manager.get_file_path()
-    
-    # Ensure directory exists for new extension-based paths
-    apriori_path_f.parent.mkdir(parents=True, exist_ok=True)
 
     # save file
 
@@ -211,9 +208,6 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     # Use FileManagement to get JSON file path with new directory structure
     json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
     json_path = json_manager.get_file_path()
-    
-    # Ensure directory exists for new structure
-    json_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(json_path, 'w+') as outfile:
         json.dump(lsp, outfile, indent=4)

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -130,14 +130,18 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     # four quadrants
     azimuth_list = [0, 90, 180, 270]
 
-    # get the satellites for the requested frequency (20 for now) and most recent year
+    # get the satellites for the requested frequency and most recent year
     if (fr == 1):
         l1_satellite_list = np.arange(1,33)
         satellite_list = l1_satellite_list
 
         # Uncomment to use experimental L1C_list function, for filtering to GPS BLock III
         #satellite_list = l1c_list(year, 365)
-    else:
+    elif (fr == 5):
+        print('Using L5 satellite list for December 31 on ', year)
+        l2c_sat, l5_sat = l2c_l5_list(year, 365)
+        satellite_list = l5_sat
+    else:  # fr == 20 (L2C)
         print('Using L2C satellite list for December 31 on ', year)
         l2c_sat, l5_sat = l2c_l5_list(year, 365)
         satellite_list = l2c_sat

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -208,12 +208,14 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     lsp['vwc_minvalperday'] = minvalperday # this is how many unique tracks you need on each day 
     lsp['vwc_min_req_pts_track'] = min_tracks # this is total number of days needed to keep a satellite
 
-    if len(extension)==0:
-        instructions = str(os.environ['REFL_CODE']) + '/input/' + station + '.json'
-    else:
-        instructions = str(os.environ['REFL_CODE']) + '/input/' + station + '.' + extension + '.json'
+    # Use FileManagement to get JSON file path with new directory structure
+    json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
+    json_path = json_manager.get_file_path()
+    
+    # Ensure directory exists for new structure
+    json_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(instructions, 'w+') as outfile:
+    with open(json_path, 'w+') as outfile:
         json.dump(lsp, outfile, indent=4)
 
 

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -17,7 +17,7 @@ def parse_arguments():
     parser.add_argument("year", help="year", type=int)
     parser.add_argument("-min_tracks", default=None, help="min number of daily tracks to keep the series (default is 100)", type=int)
     parser.add_argument("-minvalperday", default=None, help="min number of tracks needed on one day to compute VWC (default is 10)", type=int)
-    parser.add_argument("-fr", default=None, help="frequency (default is L2C)", type=int)
+    parser.add_argument("-fr", default=None, help="frequency: 1 (L1), 20 (L2C), 5 (L5). Only L2C officially supported.", type=int)
     parser.add_argument("-extension", default='', help="analysis extension parameter", type=str)
     parser.add_argument("-tmin", default=0.05, help="min soil texture", type=float)
     parser.add_argument("-tmax", default=0.5, help="max soil texture", type=float)
@@ -56,7 +56,7 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     year : int
         full year
     fr : int, optional
-        GPS frequency. Currently only supports l2c, which is frequency 20.
+        GPS frequency: 1 (L1), 20 (L2C), 5 (L5). Only L2C is officially supported.
     min_tracks : int, optional
         number of minimum daily tracks needed in order to keep that satellite track
     minvalperday : int, optional

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -171,7 +171,7 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
                 apriori_array.append([b, np.mean(reflector_heights), satellite, average_azimuth, len(reflector_heights), azimuth_min, azimuth_max])
 
     # Use FileManagement with frequency and extension support
-    file_manager = FileManagement(station, FileTypes.apriori_rh_file, frequency=fr, extension=extension)
+    file_manager = FileManagement(station, 'apriori_rh_file', frequency=fr, extension=extension)
     apriori_path_f = file_manager.get_file_path()
 
     # save file
@@ -206,7 +206,7 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
     lsp['vwc_min_req_pts_track'] = min_tracks # this is total number of days needed to keep a satellite
 
     # Use FileManagement to get JSON file path with new directory structure
-    json_manager = FileManagement(station, FileTypes.make_json, extension=extension)
+    json_manager = FileManagement(station, 'make_json', extension=extension)
     json_path = json_manager.get_file_path()
 
     with open(json_path, 'w+') as outfile:

--- a/gnssrefl/vwc_input.py
+++ b/gnssrefl/vwc_input.py
@@ -137,13 +137,10 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
 
         # Uncomment to use experimental L1C_list function, for filtering to GPS BLock III
         #satellite_list = l1c_list(year, 365)
-
-        apriori_path_f = myxdir + '/input/' + station + '_phaseRH_L1.txt'
     else:
         print('Using L2C satellite list for December 31 on ', year)
         l2c_sat, l5_sat = l2c_l5_list(year, 365)
         satellite_list = l2c_sat
-        apriori_path_f = myxdir + '/input/' + station + '_phaseRH.txt'
 
 
     # window out frequency 20
@@ -173,7 +170,12 @@ def vwc_input(station: str, year: int, fr: str = None, min_tracks: int = 100, mi
                 #print("{0:3.0f} {1:5.2f} {2:2.0f} {3:7.2f} {4:3.0f} {5:3.0f} {6:3.0f} ".format(b, np.mean(reflector_heights), satellite, average_azimuth, len(reflector_heights),azimuth_min,azimuth_max))
                 apriori_array.append([b, np.mean(reflector_heights), satellite, average_azimuth, len(reflector_heights), azimuth_min, azimuth_max])
 
-    apriori_path = FileManagement(station, FileTypes("apriori_rh_file")).get_file_path()
+    # Use FileManagement with frequency and extension support
+    file_manager = FileManagement(station, FileTypes.apriori_rh_file, frequency=fr, extension=extension)
+    apriori_path_f = file_manager.get_file_path()
+    
+    # Ensure directory exists for new extension-based paths
+    apriori_path_f.parent.mkdir(parents=True, exist_ok=True)
 
     # save file
 

--- a/test/test_file_management.py
+++ b/test/test_file_management.py
@@ -1,0 +1,356 @@
+"""
+Unit tests for FileManagement class improvements in the improved_RH_filestructure branch.
+
+Tests cover:
+- New directory structure implementation
+- Backwards compatibility fallback logic
+- Extension parameter handling
+- Edge cases and error conditions
+- Path resolution priority
+
+These tests are designed to run fast and locally without requiring external data processing.
+"""
+
+import os
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from gnssrefl.utils import FileManagement, FileTypes
+
+
+@pytest.fixture
+def temp_refl_code():
+    """Create a temporary REFL_CODE directory structure for testing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        
+        # Create basic directory structure
+        (temp_path / "input").mkdir()
+        (temp_path / "Files").mkdir()
+        (temp_path / "2023" / "phase").mkdir(parents=True)
+        
+        with patch.dict(os.environ, {'REFL_CODE': str(temp_path)}):
+            yield temp_path
+
+
+class TestFileManagementBasics:
+    """Test basic FileManagement functionality."""
+    
+    def test_string_file_type_conversion(self, temp_refl_code):
+        """Test that string file types are properly converted to FileTypes enum."""
+        fm = FileManagement("TEST", "make_json")
+        assert fm.file_type == FileTypes.make_json
+    
+    def test_invalid_string_file_type_raises_error(self, temp_refl_code):
+        """Test that invalid string file types raise appropriate error."""
+        with pytest.raises(ValueError, match="Unknown file type: 'invalid_type'"):
+            FileManagement("TEST", "invalid_type")
+    
+    def test_enum_file_type_accepted(self, temp_refl_code):
+        """Test that FileTypes enum values are accepted directly."""
+        fm = FileManagement("TEST", FileTypes.make_json)
+        assert fm.file_type == FileTypes.make_json
+
+
+class TestJSONFileHandling:
+    """Test JSON file path resolution and fallback logic."""
+    
+    def test_json_path_no_extension_new_format(self, temp_refl_code):
+        """Test JSON path generation for new directory structure without extension."""
+        fm = FileManagement("TEST", "make_json")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "input" / "TEST" / "TEST.json"
+        assert path == expected
+        # Directory should be created
+        assert path.parent.exists()
+    
+    def test_json_path_with_extension_new_format(self, temp_refl_code):
+        """Test JSON path generation for new directory structure with extension."""
+        fm = FileManagement("TEST", "make_json", extension="custom")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "input" / "TEST" / "custom" / "TEST.json"
+        assert path == expected
+        assert path.parent.exists()
+    
+    def test_json_fallback_no_extension(self, temp_refl_code):
+        """Test JSON file fallback from new to legacy format without extension."""
+        # Create legacy file
+        legacy_path = temp_refl_code / "input" / "TEST.json"
+        legacy_path.write_text('{"test": "data"}')
+        
+        fm = FileManagement("TEST", "make_json")
+        found_path, format_type = fm.find_json_file()
+        
+        assert found_path == legacy_path
+        assert format_type == "legacy_station"
+    
+    def test_json_fallback_with_extension(self, temp_refl_code):
+        """Test JSON file fallback from new to legacy format with extension."""
+        # Create legacy extension file
+        legacy_path = temp_refl_code / "input" / "TEST.custom.json"
+        legacy_path.write_text('{"test": "data"}')
+        
+        fm = FileManagement("TEST", "make_json", extension="custom")
+        found_path, format_type = fm.find_json_file()
+        
+        assert found_path == legacy_path
+        assert format_type == "legacy_extension"
+    
+    def test_json_priority_new_over_legacy(self, temp_refl_code):
+        """Test that new format takes priority over legacy when both exist."""
+        # Create both legacy and new format files
+        legacy_path = temp_refl_code / "input" / "TEST.json"
+        legacy_path.write_text('{"legacy": "data"}')
+        
+        new_dir = temp_refl_code / "input" / "TEST"
+        new_dir.mkdir()
+        new_path = new_dir / "TEST.json"
+        new_path.write_text('{"new": "data"}')
+        
+        fm = FileManagement("TEST", "make_json")
+        found_path, format_type = fm.find_json_file()
+        
+        assert found_path == new_path
+        assert format_type == "station_dir"
+
+
+class TestAprioriRHFileHandling:
+    """Test apriori RH file path resolution and frequency handling."""
+    
+    def test_apriori_rh_l2_default(self, temp_refl_code):
+        """Test apriori RH path for L2 (default frequency)."""
+        fm = FileManagement("TEST", "apriori_rh_file", frequency=20)
+        path = fm.get_file_path()
+        expected = temp_refl_code / "input" / "TEST" / "TEST_phaseRH_L2.txt"
+        assert path == expected
+    
+    def test_apriori_rh_l1(self, temp_refl_code):
+        """Test apriori RH path for L1 frequency."""
+        fm = FileManagement("TEST", "apriori_rh_file", frequency=1)
+        path = fm.get_file_path()
+        expected = temp_refl_code / "input" / "TEST" / "TEST_phaseRH_L1.txt"
+        assert path == expected
+    
+    def test_apriori_rh_l5(self, temp_refl_code):
+        """Test apriori RH path for L5 frequency (experimental)."""
+        fm = FileManagement("TEST", "apriori_rh_file", frequency=5)
+        path = fm.get_file_path()
+        expected = temp_refl_code / "input" / "TEST" / "TEST_phaseRH_L5.txt"
+        assert path == expected
+    
+    def test_apriori_rh_with_extension(self, temp_refl_code):
+        """Test apriori RH path with extension."""
+        fm = FileManagement("TEST", "apriori_rh_file", frequency=20, extension="custom")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "input" / "TEST" / "custom" / "TEST_phaseRH_L2.txt"
+        assert path == expected
+    
+    def test_apriori_rh_legacy_fallback_l2(self, temp_refl_code):
+        """Test apriori RH fallback to legacy L2 format."""
+        # Create legacy L2 file (no frequency suffix for backwards compatibility)
+        legacy_path = temp_refl_code / "input" / "TEST_phaseRH.txt"
+        legacy_path.write_text("# Legacy L2 data")
+        
+        fm = FileManagement("TEST", "apriori_rh_file", frequency=20)
+        found_path, is_legacy = fm.find_apriori_rh_file()
+        
+        assert found_path == legacy_path
+        assert is_legacy is True
+    
+    def test_apriori_rh_legacy_fallback_l1(self, temp_refl_code):
+        """Test apriori RH fallback to legacy L1 format."""
+        # Create legacy L1 file
+        legacy_path = temp_refl_code / "input" / "TEST_phaseRH_L1.txt"
+        legacy_path.write_text("# Legacy L1 data")
+        
+        fm = FileManagement("TEST", "apriori_rh_file", frequency=1)
+        found_path, is_legacy = fm.find_apriori_rh_file()
+        
+        assert found_path == legacy_path
+        assert is_legacy is True
+
+
+class TestPhaseFileHandling:
+    """Test phase file path generation with extension support."""
+    
+    def test_phase_file_path_basic(self, temp_refl_code):
+        """Test basic phase file path generation."""
+        fm = FileManagement("TEST", "phase_file", year=2023, doy=100)
+        path = fm.get_file_path()
+        expected = temp_refl_code / "2023" / "phase" / "TEST" / "100.txt"
+        assert path == expected
+    
+    def test_phase_file_path_with_extension(self, temp_refl_code):
+        """Test phase file path generation with extension."""
+        fm = FileManagement("TEST", "phase_file", year=2023, doy=100, extension="custom")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "2023" / "phase" / "TEST" / "custom" / "100.txt"
+        assert path == expected
+    
+    def test_phase_file_requires_year_doy(self, temp_refl_code):
+        """Test that phase file generation works with year and doy parameters."""
+        # This should not raise an error when year and doy are provided
+        fm = FileManagement("TEST", "phase_file", year=2023, doy=100)
+        path = fm.get_file_path()
+        assert "2023" in str(path)
+        assert "100.txt" in str(path)
+
+
+class TestVolumetricWaterContentFiles:
+    """Test volumetric water content file handling."""
+    
+    def test_vwc_path_no_extension(self, temp_refl_code):
+        """Test VWC file path without extension."""
+        fm = FileManagement("TEST", "volumetric_water_content")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "Files" / "TEST" / "TEST_vwc.txt"
+        assert path == expected
+    
+    def test_vwc_path_with_extension(self, temp_refl_code):
+        """Test VWC file path with extension."""
+        fm = FileManagement("TEST", "volumetric_water_content", extension="custom")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "Files" / "TEST" / "custom" / "TEST_vwc.txt"
+        assert path == expected
+
+
+class TestDailyAvgPhaseFiles:
+    """Test daily average phase file handling."""
+    
+    def test_daily_avg_phase_path_no_extension(self, temp_refl_code):
+        """Test daily avg phase file path without extension."""
+        fm = FileManagement("TEST", "daily_avg_phase_results")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "Files" / "TEST" / "TEST_phase.txt"
+        assert path == expected
+    
+    def test_daily_avg_phase_path_with_extension(self, temp_refl_code):
+        """Test daily avg phase file path with extension."""
+        fm = FileManagement("TEST", "daily_avg_phase_results", extension="custom")
+        path = fm.get_file_path()
+        expected = temp_refl_code / "Files" / "TEST" / "custom" / "TEST_phase.txt"
+        assert path == expected
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+    
+    def test_empty_string_extension_vs_none(self, temp_refl_code):
+        """Test that empty string extension behaves the same as no extension."""
+        fm_empty = FileManagement("TEST", "make_json", extension="")
+        fm_none = FileManagement("TEST", "make_json", extension=None)
+        
+        # Both should generate the same path structure (no extension subdirectory)
+        path_empty = fm_empty.get_file_path()
+        path_none = fm_none.get_file_path()
+        
+        expected = temp_refl_code / "input" / "TEST" / "TEST.json"
+        assert path_empty == expected
+        assert path_none == expected
+    
+    def test_extension_sanitization_not_implemented(self, temp_refl_code):
+        """Test that extension with special characters is not currently sanitized."""
+        # This test documents current behavior - extensions are used as-is
+        fm = FileManagement("TEST", "make_json", extension="test/bad")
+        path = fm.get_file_path()
+        
+        # This will create a path with the problematic extension
+        # In a production system, you'd want to sanitize this
+        assert "test/bad" in str(path)
+    
+    def test_directory_creation_disabled(self, temp_refl_code):
+        """Test that directory creation can be disabled."""
+        fm = FileManagement("TEST", "make_json", extension="newdir")
+        path = fm.get_file_path(ensure_directory=False)
+        
+        # Directory should not exist
+        assert not path.parent.exists()
+        
+        # But path should still be correct
+        expected = temp_refl_code / "input" / "TEST" / "newdir" / "TEST.json"
+        assert path == expected
+    
+    def test_invalid_file_type_enum_error(self, temp_refl_code):
+        """Test error handling for invalid FileTypes enum access."""
+        fm = FileManagement("TEST", "make_json")
+        
+        # Manually set an invalid file type to test error handling
+        fm.file_type = "invalid_type"
+        
+        with pytest.raises(ValueError, match="The file type you requested does not exist"):
+            fm.get_file_path()
+
+
+class TestBackwardsCompatibility:
+    """Test backwards compatibility scenarios."""
+    
+    def test_mixed_legacy_new_files_priority(self, temp_refl_code):
+        """Test behavior when both legacy and new format files exist."""
+        station = "TEST"
+        
+        # Create legacy JSON file
+        legacy_json = temp_refl_code / "input" / f"{station}.json"
+        legacy_json.write_text('{"legacy": true}')
+        
+        # Create new format JSON file
+        new_dir = temp_refl_code / "input" / station
+        new_dir.mkdir()
+        new_json = new_dir / f"{station}.json"
+        new_json.write_text('{"new": true}')
+        
+        fm = FileManagement(station, "make_json")
+        found_path, format_type = fm.find_json_file()
+        
+        # New format should take priority
+        assert found_path == new_json
+        assert format_type == "station_dir"
+    
+    def test_extension_fallback_behavior(self, temp_refl_code):
+        """Test extension fallback behavior matches documentation."""
+        station = "TEST"
+        extension = "custom"
+        
+        # Create only legacy extension file
+        legacy_ext = temp_refl_code / "input" / f"{station}.{extension}.json"
+        legacy_ext.write_text('{"extension": "legacy"}')
+        
+        fm = FileManagement(station, "make_json", extension=extension)
+        found_path, format_type = fm.find_json_file()
+        
+        assert found_path == legacy_ext
+        assert format_type == "legacy_extension"
+
+
+class TestFrequencyMapping:
+    """Test frequency to suffix mapping logic."""
+    
+    def test_frequency_mapping_consistency(self, temp_refl_code):
+        """Test that frequency mapping is consistent across file types."""
+        # L2C (20) should map to L2
+        fm_l2c = FileManagement("TEST", "apriori_rh_file", frequency=20)
+        path_l2c = fm_l2c._get_apriori_rh_path()
+        assert "L2" in str(path_l2c)
+        
+        # L1 (1) should map to L1
+        fm_l1 = FileManagement("TEST", "apriori_rh_file", frequency=1)
+        path_l1 = fm_l1._get_apriori_rh_path()
+        assert "L1" in str(path_l1)
+        
+        # L5 (5) should map to L5
+        fm_l5 = FileManagement("TEST", "apriori_rh_file", frequency=5)
+        path_l5 = fm_l5._get_apriori_rh_path()
+        assert "L5" in str(path_l5)
+    
+    def test_default_frequency_handling(self, temp_refl_code):
+        """Test default frequency handling when none specified."""
+        fm = FileManagement("TEST", "apriori_rh_file")  # No frequency specified
+        path = fm._get_apriori_rh_path()
+        # Should default to L2
+        assert "L2" in str(path)
+
+
+if __name__ == "__main__":
+    # Allow running tests directly with: python test_file_management.py
+    pytest.main([__file__, "-v"])

--- a/test/test_file_management.py
+++ b/test/test_file_management.py
@@ -154,10 +154,10 @@ class TestAprioriRHFileHandling:
         legacy_path.write_text("# Legacy L2 data")
         
         fm = FileManagement("TEST", "apriori_rh_file", frequency=20)
-        found_path, is_legacy = fm.find_apriori_rh_file()
+        found_path, format_type = fm.find_apriori_rh_file()
         
         assert found_path == legacy_path
-        assert is_legacy is True
+        assert format_type == 'legacy'
     
     def test_apriori_rh_legacy_fallback_l1(self, temp_refl_code):
         """Test apriori RH fallback to legacy L1 format."""
@@ -166,10 +166,10 @@ class TestAprioriRHFileHandling:
         legacy_path.write_text("# Legacy L1 data")
         
         fm = FileManagement("TEST", "apriori_rh_file", frequency=1)
-        found_path, is_legacy = fm.find_apriori_rh_file()
+        found_path, format_type = fm.find_apriori_rh_file()
         
         assert found_path == legacy_path
-        assert is_legacy is True
+        assert format_type == 'legacy'
 
 
 class TestPhaseFileHandling:


### PR DESCRIPTION
## Summary

This PR implements L5 frequency support for the vwc_input, phase, and vwc commands. To support this, the FileManagement class was extended and is now integrated throughout gnssir_input, gnssir, vwc_input, phase, and vwc code. I have made some changes to the location of files (json/RH) to support extensions and multiple RH files cleanly, but there is backwards compatibility with legacy config file locations. 

## Example Workflow

```
# --- L1 Analysis ---
gnssir_input p038 -fr 1 -extension signal_l1
gnssir p038 2024 1 -doy_end 365 -extension signal_l1
vwc_input p038 2024 -extension signal_l1
phase p038 2024 1 -doy_end 365 -extension signal_l1
vwc p038 2024 -extension signal_l1

# --- L2C Analysis ---
gnssir_input p038 -fr 20            # Note I'm choosing not to use an extension as an example
gnssir p038 2024 1 -doy_end 365
vwc_input p038 2024
phase p038 2024 1 -doy_end 365
vwc p038 2024

# --- L5 Analysis ---
gnssir_input p038 -fr 5 -extension signal_l5
gnssir p038 2024 1 -doy_end 365 -extension signal_l5
vwc_input p038 2024 -extension signal_l5
phase p038 2024 1 -doy_end 365 -extension signal_l5
vwc p038 2024 -extension signal_l5
```

## Example Results

The L5 results are excellent! 

<img width="1500" height="800" alt="full_signal_comparison" src="https://github.com/user-attachments/assets/cbb31760-01df-4e0c-8248-ccb104cae30b" />

## Why refactor FileManagement?

The code was originally designed for L2C, and L1 support was "tacked on" by repeating/branching code where required. Naively adding L5 support would be "tacking on" even more duplicate code. Additionally, a lot of path creation logic was duplicated in multiple locations making maintenance harder. 

The new FileManagement class centralizes logic for folder/file creation and path generation while being easily extendable. It meant that adding L5 support required changing < 10 lines of code. Extending the class to also support management of the arcs/ folder was simple (mostly in commit a25d54d). 

## Changes to Directory Structure

**New Structure**:
```
input/{station}/{extension}/{station}.json                 # JSON configurations
input/{station}/{extension}/{station}_phaseRH_L{freq}.txt  # RH files  
{year}/arcs/{station}/{extension}/{doy}/                   # Arc files (savearcs)
```

**Legacy Structure** (automatic, silent fallback):
```
input/{station}.{extension}.json       # Legacy JSON
input/{station}_phaseRH_*.txt          # Legacy RH files, no _L2 suffix
{year}/arcs/{station}/{doy}/           # Legacy arc directories, no extension support
```

For example, the workflow above will produce the following files:

```
$REFL_CODE/
├── input/
│   ├── p038/
│   │   ├── signal_l1/
│   │   │   ├── p038.json
│   │   │   └── p038_phaseRH_L1.txt
│   │   └── signal_l5/
│   │       ├── p038.json
│   │       └── p038_phaseRH_L5.txt
│   ├── p038.json                    # L2C analysis (no extension)
│   └── p038_phaseRH_L2.txt         # L2C analysis (no extension)
├── Files/
│   └── p038/
│       ├── signal_l1/
│       │   └── p038_vwc.txt
│       ├── signal_l5/
│       │   └── p038_vwc.txt
│       └── p038_vwc.txt            # L2C analysis (no extension)
└── 2024/
    └── arcs/                       # if -savearcs used
        └── p038/
            ├── signal_l1/
            │   └── 001/
            ├── signal_l5/
            │   └── 001/
            └── 001/                # L2C arcs (no extension)
```

Some changes compared with what would be produced previously:

```
$REFL_CODE/
├── input/                          # Flat input directory
│   ├── p038.json
│   ├── p038.signal_l5.json         # {station}.{extension}.json format
│   ├── p038.signal_l1.json                 
│   └── p038_phaseRH.txt            # L2 signal has no extension, single RH file per freq for all extensions
│   └── p038_phaseRH_L1.txt 
│   └── p038_phaseRH_L5.txt 
└── 2024/
    └── arcs/
        └── p038/
            └── 001/                # No extension support for arcs
```

The FileManagement implementation will automatically search for legacy config files (e.g. "input/p038_phaseRH_L1.txt") if it does not find a file at the new location ("input/p038/signal_l1/p038_phaseRH_L1.txt") and notify the user that it has fallen back to a file in a legacy directory. 


## Testing Suite

I have used an LLM (Claude) to generate some unit tests for the FileManagement implementation which I believe will integrate automatically with the GitHub testing environment. I don't personally have a lot of experience with testing (and I see there are few existing tests in gnssrefl) but it seems like a useful addition to ensure the directory structures stay consistent. The tests include: 

- **Basic FileManagement functionality**: File type validation, string/enum conversion, error handling
- **JSON file handling**: New vs legacy format priority, extension fallback scenarios  
- **Apriori RH files**: All frequency mappings (L1, L2C, L5) with legacy compatibility testing
- **Phase and VWC files**: Extension support, directory creation, year/doy parameters
- **Edge cases**: Empty extensions, mixed legacy/new file scenarios, directory creation control
- **Search priority logic**: Verification that new format takes precedence over legacy
- **Format type reporting**: Correct identification of file source ('new_format', 'legacy', etc.)

## Feedback

I understand these are relatively large changes to the codebase. If you'd prefer, I can resubmit this as a smaller PR without the directory changes focused solely on L5 support, or resubmit based on any other feedback you have. Let me know if you have any questions. Thanks for your time. 