### PR TITLE
Replace np.genfromtxt with np.loadtxt from loading .snr files

### DIFF
--- a/gnssrefl/gnssir_v2.py
+++ b/gnssrefl/gnssir_v2.py
@@ -777,7 +777,7 @@ def read_snr(obsfile):
     """
     allGood = 1
     if os.path.isfile(obsfile):
-        f = np.genfromtxt(obsfile,comments='%')
+        f = np.loadtxt(obsfile,comments='%')
     else:
         print('No SNR file found')
         allGood = 0

--- a/gnssrefl/read_snr_files.py
+++ b/gnssrefl/read_snr_files.py
@@ -204,7 +204,7 @@ def read_one_snr(obsfile,ifile):
 #
 
     snrE = np.array([False, True, True,False,False,True,True,True,True],dtype = bool)
-    f = np.genfromtxt(obsfile,comments='%')
+    f = np.loadtxt(obsfile,comments='%')
     #print('reading from this snr file ',obsfile)
     r,c = f.shape
     if (r > 0) & (c > 0):


### PR DESCRIPTION
## Summary 

We can make loading SNR files 5x faster by changing the numpy function used to load SNR files. Apparently, there is a lot of overhead when using np.genfromtxt instead of np.loadtxt. Because the snrfiles are so well formatted, I think we can just use np.loadtxt (unless you know of a compatibility reason to use genfromtxt?). 

## File Loading Benchmark

Here is some benchmark code you can run to test how quickly each function loads an SNR file:

```
import timeit

SNR_FILE = 'p0380010.24.snr66.gz'
NUM_RUNS = 10
SETUP_CODE = f"import numpy as np; filename='{SNR_FILE}'"

t_genfromtxt = timeit.timeit("np.genfromtxt(filename, comments='%')", setup=SETUP_CODE, number=NUM_RUNS) / NUM_RUNS
t_loadtxt = timeit.timeit("np.loadtxt(filename, comments='%')", setup=SETUP_CODE, number=NUM_RUNS) / NUM_RUNS

print(f"np.genfromtxt: {t_genfromtxt:.4f}s")
print(f"np.loadtxt:    {t_loadtxt:.4f}s ({t_genfromtxt/t_loadtxt:.1f}x faster)")
```

Results (on my NVME SSD + r7 5700x CPU with a 6MB snrfile): 

```
np.genfromtxt: 0.2491s
np.loadtxt:    0.0503s (5.0x faster)
```

So about 0.2s saved per file loaded. 

## gnssir benchmark

This directly leads to a speedup in the gnssir and phase commands. For example, running ```gnssir p038 2024 1 -doy_end 50``` and manually recording the run times (from the printed output) I got the following results:

```
No par, np.genfromtxt: 77.51 s, 71.59 s, 71.36 s (average 73.49 s)
No par, np.loadtxt: 62.11 s, 61.19 s, 60.88 s (average 61.39 s)

-par 5, np.genfromtxt: 36.4 s, 39.85 s, 38.96 s (average 38.40 s)
-par 5, np.loadtxt: 37.27 s, 34.14 s, 37.56 s (average 36.32 s) 
```