### PR TITLE
Implement parallel processing for phase command

### DIFF
--- a/gnssrefl/quickPhase.py
+++ b/gnssrefl/quickPhase.py
@@ -1,8 +1,12 @@
 import argparse
 import numpy as np
 import sys
+import time
+import multiprocessing
+from functools import partial
 
 import gnssrefl.gps as g
+import gnssrefl.gnssir_v2 as guts2
 import gnssrefl.phase_functions as qp
 from gnssrefl.utils import str2bool
 
@@ -22,6 +26,7 @@ def parse_arguments():
     parser.add_argument("-plt", default=None, type=str, help="plots come to the screen - which you do not want!")
     parser.add_argument("-screenstats", default=None, type=str, help="stats come to the screen")
     parser.add_argument("-gzip", default=None, type=str, help="gzip SNR files after use, default is True" )
+    parser.add_argument("-par", default=None, type=int, help="Number of processes to spawn (up to 10)")
 
     args = parser.parse_args().__dict__
 
@@ -34,7 +39,7 @@ def parse_arguments():
 
 
 def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end: int = None, snr: int = 66,
-        fr: str = None, e1: float = 5, e2: float = 30, plt: bool = False, screenstats: bool = False, gzip: bool = True, extension: str = ''):
+        fr: str = None, e1: float = 5, e2: float = 30, plt: bool = False, screenstats: bool = False, gzip: bool = True, extension: str = '', par: int = None):
     """
     quickphase computes phase, which are subquently used in vwc. The command line call is phase
     (which maybe we should change).
@@ -46,6 +51,9 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
 
     phase p038 2021 1 -doy_end 365 
         analyzes data for the whole year
+
+    phase p038 2021 1 -doy_end 365 -par 5
+        analyzes data for the whole year using 5 parallel processes
 
     Parameters
     ----------
@@ -86,6 +94,8 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
         Whether to print stats to the screen. Default is False
     gzip : bool, optional
         gzip the SNR file after use.  Default is True
+    par : int, optional
+        Number of parallel processes to spawn (up to 10). Default is 1 (single process).
 
     Returns
     -------
@@ -114,6 +124,10 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
     # in case you want to analyze multiple days of data
     if not doy_end:
         doy_end = doy
+    
+    # in case you want to analyze only data within one year
+    if not year_end:
+        year_end = year
 
     exitS = g.check_inputs(station, year, doy, snr)
 
@@ -125,8 +139,61 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
     # this should really be read from the json
     pele = [5, 30]  # polynomial fit limits  for direct signal
 
-    # TODO maybe instead of specific doy we can do only year and pick up all those files just like the other parts?
-    if year_end:
+    # Set up timing and parallel processing
+    t1 = time.time()
+    
+    # Set default for par and validate
+    if isinstance(par, type(None)):
+        par = 1
+    
+    if not isinstance(par, int) or par <= 0 or par > 10:
+        print('Number of processes must be between 1 and 10. Submit again. Exiting.')
+        sys.exit()
+    
+    # Check for single day processing
+    if (year == year_end) and (doy == doy_end):
+        if par > 1:
+            print('You are analyzing only one day of data - no reason to submit multiple processes')
+            par = 1
+    
+    # Create args for worker function
+    args = {
+        'station': station, 'snr': snr, 'fr_list': fr_list, 'e1': e1, 'e2': e2,
+        'pele': pele, 'plt': plt, 'screenstats': screenstats, 'compute_lsp': compute_lsp,
+        'gzip': gzip, 'extension': extension
+    }
+    
+    if par == 1:
+        print('Sequential processing')
+        process_phase_sequential(year, year_end, doy, doy_end, args)
+    else:
+        print('Parallel processing chosen')
+        process_phase_parallel(year, year_end, doy, doy_end, args, par)
+    
+    t2 = time.time()
+    print('Time to compute: ', round(t2-t1, 2), ' seconds')
+
+
+def process_phase_day(year, doy, args, error_queue=None):
+    """Process a single day - shared by both sequential and parallel processing"""
+    try:
+        print(f'Analyzing year/day of year {year}/{doy}')
+        qp.phase_tracks(args['station'], year, doy, args['snr'], args['fr_list'], 
+                       args['e1'], args['e2'], args['pele'], args['plt'], 
+                       args['screenstats'], args['compute_lsp'], args['gzip'], args['extension'])
+    except Exception as e:
+        if error_queue:
+            print('***********************************************************************')
+            print('Error in phase processing: ', year, doy)
+            print('***********************************************************************')
+            error_queue.put(e)
+        else:
+            raise
+
+def process_phase_sequential(year, year_end, doy, doy_end, args):
+    """Sequential processing function"""
+    # Original logic preserved
+    if year_end != year:  # Multi-year processing
         year_range = np.arange(year, year_end+1)
         for y in np.arange(year, year_end+1):
             # If first year in multi-year range, then start on doy requested and finish year.
@@ -140,12 +207,44 @@ def quickphase(station: str, year: int, doy: int, year_end: int = None, doy_end:
                 date_range = np.arange(1, 366)
 
             for d in date_range:
-                print('Analyzing year/day of year ' + str(y) + '/' + str(d))
-                qp.phase_tracks(station, y, d, snr, fr_list, e1, e2, pele, plt, screenstats, compute_lsp, gzip, extension)
-    else:
+                process_phase_day(y, d, args)
+    else:  # Single year processing
         for d in np.arange(doy, doy_end + 1):
-            qp.phase_tracks(station, year, d, snr, fr_list, e1, e2, pele, plt, screenstats, compute_lsp, gzip, extension)
+            process_phase_day(year, d, args)
 
+def process_phase_parallel(year, year_end, doy, doy_end, args, par):
+    """Parallel processing setup and execution"""
+    manager = multiprocessing.Manager()
+    error_queue = manager.Queue()
+    
+    numproc = par
+    print(year, doy, year_end, doy_end)
+    # Get date ranges for parallel processing
+    d, numproc = guts2.make_parallel_proc_lists_mjd(year, doy, year_end, doy_end, numproc)
+    
+    # Create list of (year, doy, args, error_queue) for each day to process
+    day_list = []
+    for index in range(numproc):
+        d1 = d[index][0]
+        d2 = d[index][1]
+        for MJD in range(d1, d2+1):
+            year_mjd, doy_mjd = g.modjul_to_ydoy(MJD)
+            day_list.append((year_mjd, doy_mjd, args, error_queue))
+    
+    pool = multiprocessing.Pool(processes=numproc)
+    pool.starmap(process_phase_day, day_list)
+    pool.close()
+    pool.join()
+    
+    # Check for errors
+    if not error_queue.empty():
+        print("One (or more) of the processes encountered errors. Will not proceed until errors are fixed.")
+        i = 1
+        while not error_queue.empty():
+            e = error_queue.get()
+            print(f"Error {i} type: {type(e)}. Error {i} message: {e}")
+            i += 1
+        sys.exit(1)
 
 def main():
     args = parse_arguments()


### PR DESCRIPTION
This PR extends the ```-par``` flag to the ```phase``` command, with the same functionality as in ```gnssir```: 

```
phase p038 2024 1 -doy_end 365
Time to compute:  315.18  seconds
```

```
phase p038 2024 1 -doy_end 365 -par 10
Time to compute:  63.42  seconds
```

