### PR TITLE
Optimize PyPI package installation size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+docs/ export-ignore
+notebooks/ export-ignore
+test/ export-ignore
+vendor/ export-ignore


### PR DESCRIPTION
This PR aims to fix the failed PyPI publishing: https://github.com/kristinemlarson/gnssrefl/actions/runs/22110143830/job/63903867668

The job failed (was rejected by PyPI) because recent commits had added data to the repo which pushed the total size above the default 100 MB PyPI package size limit: https://docs.pypi.org/project-management/storage-limits/#requesting-a-fi

The pypi docs explain the limit for projects is 10 GB, but I think we hit the 100 MB file limit because the existing publiushing method archives the project to a .tar.gz release file (our source distribution/"sdist"), and uploads that.

We can reproduce the sdist for the version that failed to publish:

```
git checkout master
git archive -o master_release.tar.gz HEAD
du -sh master_release.tar.gz # 113M
```

We can use a .gitattributes file and `export-ignore` as a method to remove data from the sdist while keeping it in the git repository. 

For example, if you checkout this PR which will ignore docs/, notebooks/, test/, and vendor/, then regenerate the sdist file:

```
git checkout fix-sdist-size
git archive -o master_release.tar.gz HEAD
du -sh master_release.tar.gz # 8.7M (!)
```

So the new package is only 7.7% the size of the old package, with all the same code. Readthedocs uses the git repo, which will still have everything. Github uses git repo (duh) for testing, so tests will still work. vendor/ is used by the dockerfile which has the full git repo, so is fine (installexe downloads from remote repos). 

The only downside is users who install through pypi will not have access to the docs on disk by default. Those users can still git clone for the full repository with docs.  