### PR TITLE
Handle truncated RINEX 2.11 epochs in rinpy, update UNAVCO highrate URL

### DIFF
--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -2634,8 +2634,9 @@ def rinex_unavco_highrate(station, year, month, day):
 
     rinexfile,rinexfiled = rinex_name(station, year, month, day)
 
-    #unavco = 'https://data-idm.unavco.org/archive/gnss/highrate/1-Hz/rinex/' 
-    unavco = 'https://data.unavco.org/archive/gnss/highrate/1-Hz/rinex/'
+    #unavco = 'https://data-idm.unavco.org/archive/gnss/highrate/1-Hz/rinex/'
+    #unavco = 'https://data.unavco.org/archive/gnss/highrate/1-Hz/rinex/'
+    unavco = 'https://data.earthscope.org/archive/gnss/highrate/1-Hz/rinex/'
 
 
     filename1 = rinexfile + '.Z'

--- a/gnssrefl/rinpy.py
+++ b/gnssrefl/rinpy.py
@@ -123,7 +123,11 @@ def _readheader_v21x(lines):
 
     while i < len(lines):
         if pattern.match(lines[i][:6]):  # then it's the first line in a header record
-            if int(lines[i][28]) in (0, 1, 6):  # CHECK EPOCH FLAG  STATUS
+            try:
+                epochflag = int(lines[i][28])
+            except IndexError:
+                break  # truncated epoch header, stop parsing
+            if epochflag in (0, 1, 6):  # CHECK EPOCH FLAG  STATUS
                 headerlines.append(i)
                 year, month, day, hour = lines[i][1:3], lines[i][4:6], lines[i][7:9], lines[i][10:12]
                 minute, second = lines[i][13:15], lines[i][16:26]
@@ -155,9 +159,8 @@ def _readheader_v21x(lines):
                 i += numsats*rowpersat+1
 
             else:  # there was a comment or some header info
-                flag = int(lines[i][28])
-                if flag != 4:
-                    print(flag)
+                if epochflag != 4:
+                    print(epochflag)
                 skip = int(lines[i][30:32])
                 i += skip+1
         else:
@@ -352,8 +355,12 @@ def _readblocks_v21(lines, header, headerlines, headerlengths, epochsatlists, sa
     prntoidx = {}
     obstypes = {}
 
+    # skip malformed satellite entries from truncated epoch headers
     for sat in satset:
-        satlists[sat[0]].append(int(sat[1:]))
+        try:
+            satlists[sat[0]].append(int(sat[1:]))
+        except (IndexError, ValueError):
+            continue
 
     for letter in systemletters:
         satlists[letter].sort()

--- a/gnssrefl/rinpy.py
+++ b/gnssrefl/rinpy.py
@@ -367,13 +367,17 @@ def _readblocks_v21(lines, header, headerlines, headerlengths, epochsatlists, sa
     parse = fieldstruct.unpack_from
     _float = float  # local ref avoids global lookup
 
-    # Pre-pad only data lines as bytes (skip file header and epoch headers)
+    # Pre-pad only data lines as bytes (skip file header and epoch headers).
+    # try/except guards allow graceful handling of broken/truncated epochs.
     padded = [None] * len(lines)
     for headerstart, headerlength, satlist in zip(headerlines, headerlengths, epochsatlists):
         datastart = headerstart + headerlength
         end = datastart + rowpersat * len(satlist)
-        for k in range(datastart, end):
-            padded[k] = lines[k].rstrip().ljust(80).encode('ascii')
+        try:
+            for k in range(datastart, end):
+                padded[k] = lines[k].rstrip().ljust(80).encode('ascii')
+        except IndexError:
+            pass
 
     blank = b'              '  # 14 spaces — blank observation field
     _nan = np.nan
@@ -382,10 +386,10 @@ def _readblocks_v21(lines, header, headerlines, headerlengths, epochsatlists, sa
         datastart = headerstart + headerlength
         for i, sat in enumerate(satlist):
             start = datastart + rowpersat * i
-            databytes = b''.join(padded[start:start + rowpersat])
             try:
+                databytes = b''.join(padded[start:start + rowpersat])
                 fields = parse(databytes)
-            except struct.error:
+            except (struct.error, TypeError):
                 continue
 
             # List comprehension runs in optimized C bytecode vs explicit for loop


### PR DESCRIPTION
rinex2snr was broken for `rinex2snr mfle 2018 150 -archive unavco` due to a slightly misformed RINEX file. This is a rare edge case, so my fix just skips over any missing observations in broken epochs. 

# Issue

The file `mfle1500.18o` is truncated mid-epoch at the end. Line 63520 is the epoch header for 23:59:00. 18 data lines are expected from the listed satellites/observations. But the file only has 7 more lines after the header (63521–63527). It cuts off mid-way through G12's first data line and the remaining 5 satellites (G02, G06, G31,G09, G19) are completely missing. Thus, rinex2snr failes with an indexerror when it attempts to access non existent lines. 