### PR TITLE
Extend GLONASS frequency lookup to slots 25-28, use Use numpy Polynomial.fit to avoid RankWarning

### DIFF
--- a/gnssrefl/extract_arcs.py
+++ b/gnssrefl/extract_arcs.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 import numpy as np
+from numpy.polynomial import Polynomial
 from typing import List, Tuple, Optional, Dict, Any, Union
 
 import gnssrefl.gps as g
@@ -987,17 +988,18 @@ def remove_dc_component(
     if not dbhz:
         data = np.power(10, (data / 20))
 
-    # Fit polynomial on pele range if provided, otherwise full arc
+    # Fit polynomial on pele range if provided, otherwise full arc.
+    # Polynomial.fit internally maps x to [-1, 1] before fitting, which keeps
+    # the Vandermonde matrix well-conditioned and avoids numpy RankWarning.
     if pele is not None:
         pele_mask = (ele >= pele[0]) & (ele <= pele[1])
         if np.sum(pele_mask) > polyV + 1:
-            model = np.polyfit(ele[pele_mask], data[pele_mask], polyV)
+            poly = Polynomial.fit(ele[pele_mask], data[pele_mask], polyV)
         else:
-            model = np.polyfit(ele, data, polyV)
+            poly = Polynomial.fit(ele, data, polyV)
     else:
-        model = np.polyfit(ele, data, polyV)
-    fit = np.polyval(model, ele)
-    data = data - fit
+        poly = Polynomial.fit(ele, data, polyV)
+    data = data - poly(ele)
 
     return data
 

--- a/gnssrefl/extract_arcs.py
+++ b/gnssrefl/extract_arcs.py
@@ -21,7 +21,7 @@ from typing import List, Tuple, Optional, Dict, Any, Union
 import gnssrefl.gps as g
 from gnssrefl.read_snr_files import read_snr
 from gnssrefl.utils import circular_mean_deg, circular_distance_deg, FileManagement
-from gnssrefl.gnss_frequencies import get_snr_column, get_scale_factor, get_file_suffix
+from gnssrefl.gnss_frequencies import get_snr_column, get_scale_factor, get_file_suffix, get_glonass_channel
 
 # Constants
 GAP_TIME_LIMIT = 600  # seconds (10 minutes)
@@ -656,6 +656,16 @@ def extract_arcs(
         unique_sats = np.unique(sats)
     else:
         unique_sats = np.array(sat_list)
+
+    # Drop GLONASS sats whose slot has no known FDMA channel (e.g. newly launched
+    # GLONASS-K not yet in the slot table). Without this they would crash the
+    # per-arc wavelength lookup. Log once so the user sees which PRNs were skipped.
+    glonass_mask = (unique_sats >= 101) & (unique_sats <= 199)
+    if glonass_mask.any():
+        unknown = [int(s) for s in unique_sats[glonass_mask] if get_glonass_channel(int(s)) is None]
+        if unknown:
+            print(f'Skipping GLONASS sats with no known channel assignment: {unknown}')
+            unique_sats = np.array([s for s in unique_sats if int(s) not in unknown])
 
     elev_pairs = _parse_elevation_list(e1, e2, ellist)
     if screenstats and len(elev_pairs) > 1:

--- a/gnssrefl/gnss_frequencies.py
+++ b/gnssrefl/gnss_frequencies.py
@@ -19,27 +19,28 @@ def wl(freq_mhz):
     return C / (freq_mhz * 1e6)
 
 
+# GLONASS slot -> FDMA channel mapping.
+# Static snapshot; channels actually vary over time (the authoritative value is
+# carried per-record in the GLONASS broadcast nav file) and a future fix should
+# read them from the nav ephemeris.
+#
+# Slots 1-24: long-standing mapping from Simon Williams (originally in gps.py, ported in v4.1.3).
+# Slots 25-28: current as of early 2026 per IGS satellite metadata
+# (files.igs.org/pub/station/general/igs_satellite_metadata.snx).
+# Slot 25 is the historical value; outdated as of 2025:145 but previously stood for 18 years.
+_GLONASS_SLOT_CHANNEL = {
+    1: 1, 2: -4, 3: 5, 4: 6, 5: 1, 6: -4, 7: 5, 8: 6,
+    9: -2, 10: -7, 11: 0, 12: -1, 13: -2, 14: -7, 15: 0, 16: -1,
+    17: 4, 18: -3, 19: 3, 20: 2, 21: 4, 22: -3, 23: 3, 24: 2,
+    25: 3, 26: -6, 27: -5, 28: 7,
+}
+
+
 def get_glonass_channel(prn):
-    """Return the FDMA channel number for a GLONASS satellite.
-
-    Parameters
-    ----------
-    prn : int
-        satellite number (slot, 1-24, with or without the 100-offset)
-
-    Returns
-    -------
-    int
-        channel number in the range -7..+6
-
-    Slot-to-channel mapping is fixed per GLONASS satellite assignment.
-    Logic from Simon Williams, copied from gps.py in v4.1.2.
-    """
+    """Return the FDMA channel number for a GLONASS satellite, or None if unknown."""
     if prn > 100:
         prn = prn - 100
-    slot = np.array([14,15,10,20,19,13,12,1,6,5,22,23,24,16,4,8,3,7,2,18,21,9,17,11])
-    channel = np.array([-7,0,-7,2,3,-2,-1,1,-4,1,-3,3,2,-1,6,6,5,5,-4,-3,4,-2,4,0])
-    return int(channel[slot == prn].item())
+    return _GLONASS_SLOT_CHANNEL.get(int(prn))
 
 
 def get_glonass_wavelength(f, prn):
@@ -47,8 +48,11 @@ def get_glonass_wavelength(f, prn):
 
     GLONASS uses FDMA so each satellite transmits on a slightly different
     carrier determined by its channel number. f is 101 (G1) or 102 (G2).
+    Raises ValueError if the satellite slot has no known channel assignment.
     """
     ch = get_glonass_channel(prn)
+    if ch is None:
+        raise ValueError(f'No GLONASS channel assignment known for slot {prn % 100}')
     if f == 101:
         return C / (1602e6 + ch * 0.5625e6)
     if f == 102:
@@ -62,7 +66,7 @@ def get_glonass_wavelength(f, prn):
 
 CONSTELLATIONS = {
     'GPS':     {'sat_range': (1, 33),   'offset': 0},
-    'GLONASS': {'sat_range': (101, 125), 'offset': 100},
+    'GLONASS': {'sat_range': (101, 129), 'offset': 100},
     'Galileo': {'sat_range': (201, 241), 'offset': 200},
     'BeiDou':  {'sat_range': (301, 361), 'offset': 300},
 }


### PR DESCRIPTION
## Issue

My recent addition of the `gnss_frequencies` module introduced a bug with GLONASS satellites outside of the existing defined slots 1-24. For example, in the current master for `gnssir mtma 2025 300 -debug T` I get this error:

```
  File "gnssrefl/gnssrefl/gnss_frequencies.py", line 174, in get_wavelength
    return get_glonass_wavelength(f, sat)
  File "gnssrefl/gnssrefl/gnss_frequencies.py", line 51, in get_glonass_wavelength
    ch = get_glonass_channel(prn)
  File "gnssrefl/gnssrefl/gnss_frequencies.py", line 42, in get_glonass_channel
    return int(channel[slot == prn].item())
               ~~~~~~~~~~~~~~~~~~~~~~~~~^^
ValueError: can only convert an array of size 1 to a Python scalar
```

This is due to trying to lookup a value above slot 24. 

## Fix

* Add the additional frequency slots to `_GLONASS_SLOT_CHANNEL` in `gnss_frequencies` per the IGS definition here [0]
* Add a failsafe to `extract_arcs`, so new satellites will not cause a crash in the future

## Extra fix

* Migrated np.polyfit to Polynomial.fit, which is the standard recommended by NumPy[1] to suppresses a RankWarning that occurs during edge case and spams the CLI output

[0] files.igs.org/pub/station/general/igs_satellite_metadata.snx
[1] https://numpy.org/doc/stable/reference/routines.polynomials.html