### PR TITLE
Adjust emin value for snroption 88 case

### DIFF
--- a/gnssrefl/snrfile_functions.py
+++ b/gnssrefl/snrfile_functions.py
@@ -30,7 +30,7 @@ def elev_limits(snroption):
     elif (snroption == 66):
         emin = 0; emax = 30
     elif (snroption == 88):
-        emin = 5; emax = 90
+        emin = 0; emax = 90
     else:
         emin = 5; emax = 30
 


### PR DESCRIPTION
Bug fix: restore snr88 minimum elevation to 0 deg as explained in https://gnssrefl.readthedocs.io/en/latest/pages/file_structure.html#the-snr-data-format                                                                                                               

Impact: any user running nmea2snr (after 2026-03-02, commit deab2c66) with -snr 88, gnssir with e1 < 5 gets zero retrievals. The SNR file drops all sub 5 deg observations during conversion.