### PR TITLE
Update remaining GFZ download URLs to isdc-data.gfz.de

### DIFF
--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -4876,7 +4876,7 @@ def rapid_gfz_orbits(year,month,day):
 
     gns = 'ftp://ftp.gfz-potsdam.de/pub/GNSS/products/rapid/'
 
-    new_gns = 'ftp://isdcftp.gfz-potsdam.de/gnss/products/rapid/'
+    new_gns = 'https://isdc-data.gfz.de/gnss/products/rapid/'
 
     month, day, doy, cyyyy, cyy, cdoy = ymd2ch(year,month,day)
 
@@ -6932,7 +6932,7 @@ def new_ultra_gfz_orbits(year, month, day, hour):
 
     gns = 'ftp://ftp.gfz-potsdam.de/pub/GNSS/products/ultra/'
 
-    new_gns = 'ftp://isdcftp.gfz-potsdam.de/gnss/products/ultra/'
+    new_gns = 'https://isdc-data.gfz.de/gnss/products/ultra/'
 
     month, day, doy, cyyyy, cyy, cdoy = ymd2ch(year,month,day)
 
@@ -7093,7 +7093,7 @@ def newish_gfz_orbits(year,month,day, orbtype):
 
     wk,sec = kgpsweek(year,month,day,0,0,0)
 
-    new_gns = 'ftp://isdcftp.gfz-potsdam.de/gnss/products/' + orbtype + '/'
+    new_gns = 'https://isdc-data.gfz.de/gnss/products/' + orbtype + '/'
 
     month, day, doy, cyyyy, cyy, cdoy = ymd2ch(year,month,day)
 

--- a/gnssrefl/karnak_libraries.py
+++ b/gnssrefl/karnak_libraries.py
@@ -257,7 +257,7 @@ def universal(station9ch, year, doy, archive,srate,stream,debug=False):
             dir1 = 'https://cacsa.nrcan.gc.ca/gps/data/gpsdata/' + cyy + cdoy  + '/' + cyy + 'd' + '/'
             wget.download(dir1+file_name,file_name)
         elif (archive == 'gfz'):
-            dir1 = 'ftp://isdcftp.gfz-potsdam.de/gnss/data/daily/' + cyyyy + '/' + cdoy + '/'
+            dir1 = 'https://isdc-data.gfz.de/gnss/data/daily/' + cyyyy + '/' + cdoy + '/'
             wget.download(dir1+file_name,file_name)
         elif (archive == 'cddis'):
             new_way_dir = '/gnss/data/daily/' + cyyyy + '/' + cdoy + '/' + cyy + 'd/'


### PR DESCRIPTION
This PR updates the remaining GFZ download URLs (rapid/ultra/final orbits and the daily-RINEX archive) to https://isdc-data.gfz.de after GFZ retired the isdcftp.gfz-potsdam.de FTP server on 2026-03-02 (see https://isdc.gfz.de/). 

Commit d0e45e8e (v3.15.0) already updated some links but this updates the remaining links.

Examples which are fixed:
- `download_orbits gnss-gfz 2024 1 1`: failed because the orbit fetch hit the retired isdcftp server and silently fell back to GBM, now downloads the GFZ final directly.
- `rinex2snr pots00deu 2024 1 -archive gfz`: failed because the RINEX request hit the retired isdcftp server, now succeeds. 
