### PR TITLE
Fix docker issues #417 and #418

### DIFF
--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -6067,7 +6067,7 @@ def checkEGM():
     print('local directory location ', localdir)
     if not os.path.isdir(localdir):
         print('Making ', localdir)
-        subprocess.call('mkdir',localdir)
+        os.makedirs(localdir, exist_ok=True)
 
 
     if 'REFL_CODE' in os.environ:

--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -10,6 +10,7 @@ import os
 import pickle
 import re
 import requests
+import shutil
 import subprocess
 import sys
 import sqlite3
@@ -2322,7 +2323,7 @@ def store_snrfile(filename,year,station):
         print(filename)
         print(xdir, os.path.basename(filename))
         print(os.path.join(xdir, os.path.basename(filename)))
-        os.replace(filename, os.path.join(xdir, os.path.basename(filename)))
+        shutil.move(filename, os.path.join(xdir, os.path.basename(filename)))
     else:
         print('the SNR file does not exist, so nothing was moved')
 

--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -2320,9 +2320,6 @@ def store_snrfile(filename,year,station):
     if not os.path.isdir(xdir): #if year folder doesn't exist, make it
         os.makedirs(xdir)
     if (os.path.isfile(filename) == True):
-        print(filename)
-        print(xdir, os.path.basename(filename))
-        print(os.path.join(xdir, os.path.basename(filename)))
         shutil.move(filename, os.path.join(xdir, os.path.basename(filename)))
     else:
         print('the SNR file does not exist, so nothing was moved')
@@ -6064,7 +6061,7 @@ def checkEGM():
     xdir = os.environ['REFL_CODE']
     matfile = 'EGM96geoidDATA.mat'
     localdir = xdir + '/Files'
-    print('local directory location ', localdir)
+    #print('local directory location ', localdir)
     if not os.path.isdir(localdir):
         print('Making ', localdir)
         os.makedirs(localdir, exist_ok=True)

--- a/test/test_gps.py
+++ b/test/test_gps.py
@@ -2,7 +2,11 @@ import subprocess
 from unittest import mock
 
 import os
+import shutil
 import urllib.error
+from pathlib import Path
+
+import pytest
 import wget
 
 from gnssrefl.gps import *
@@ -46,3 +50,43 @@ def test_get_sopac_navfile_error(mocker):
         mock.call(["rm", "-f", "p1031050.20.snr66.Z"]),
         mock.call(["rm", "-f", "p1031050.20.snr66"]),
     ]
+
+
+def test_store_snrfile_moves_across_filesystems(tmp_path):
+    """
+    Regression test for issue 417 (bug introduced in commit 165cd4a7).
+
+    Checks that store_snrfile moves an SNR file when the file and REFL_CODE
+    are on two different filesystems, which is what the Docker bind-mount
+    layout produces and what os.replace cannot do.
+    """
+    second_device = Path("/dev/shm")
+    if not second_device.is_dir() or second_device.stat().st_dev == tmp_path.stat().st_dev:
+        pytest.skip("no second filesystem available to exercise a cross-device move")
+
+    refl_code = second_device / f"refl_code_{os.getpid()}"
+    refl_code.mkdir()
+    try:
+        snrfile = tmp_path / "p1010010.25.snr66"
+        snrfile.write_text("snr data")
+        with mock.patch.dict(os.environ, {"REFL_CODE": str(refl_code)}):
+            store_snrfile(str(snrfile), 2025, "p101")
+        assert (refl_code / "2025" / "snr" / "p101" / "p1010010.25.snr66").is_file()
+    finally:
+        shutil.rmtree(refl_code, ignore_errors=True)
+
+
+def test_checkEGM_creates_missing_files_directory(tmp_path, mocker):
+    """
+    Regression test for issue 418.
+
+    checkEGM must create REFL_CODE/Files when it does not already exist, which
+    is the case in a fresh Docker container. The old code passed the directory
+    as the bufsize argument of subprocess.call, raising TypeError.
+    """
+    mocker.patch("wget.download")
+    refl_code = tmp_path / "refl_code"
+    refl_code.mkdir()
+    with mock.patch.dict(os.environ, {"REFL_CODE": str(refl_code)}):
+        checkEGM()
+    assert (refl_code / "Files").is_dir()


### PR DESCRIPTION
This PR fixes the two bugs in the docker build.

First, #417 was caused in v4.0.0 during the rinex2snr optimization. The previous `mv -f` call was replaced with `os.replace`, which unfortunately breaks when used inside our docker container due to bind-mounting between filesystems. I replaced it with the standard `shutil.move`.

I have also added an additional test which would have identified the bug (e.g. ensure `store_snrfile` works cross-filesystem).

Next, #418 is actually pre-existing bug dating back to v1.3.1. It occurs any time a user runs the docker container without an existing Files/ subdirectory in the refl_code path.

We set the default REFL_CODE in our docker container to /etc/gnssrefl/refl_code, however the traceback in #418 shows the user has manually changed their REFL_CODE target to `root/`: `Making /root/Files`

I have fixed this by using `os.makedirs` to create the Files/ directory when it is not present. Thus, users can now use a non-default REFL_CODE directory in docker containers without a crash.

Apologies to anyone this inconvenienced; thank you for reporting the bug!