### PR TITLE
Keep sp3 epochs across gps week rollover

### DIFF
--- a/gnssrefl/gps.py
+++ b/gnssrefl/gps.py
@@ -4012,12 +4012,8 @@ def read_sp3file(file_path):
     respectively.  all other satellites are ignored
 
     """
-    ignorePoint = False
-    max_sat = 150 # not used
     # store as satNu, week, sec of week , x, y, and z?
     rows = []
-    count = -1
-    firstEpochFound = False
 
     f = open(file_path, 'r')
     for line in f.readlines():
@@ -4026,16 +4022,7 @@ def read_sp3file(file_path):
             year,month,day,hour,minute,second = line.split()[1:]
             wk,swk = kgpsweek(int(year), int(month), int(day), int(hour), int(minute), float(second))
             wk = int(wk) ; swk = float(swk)
-            if (not firstEpochFound):
-                firstWeek = wk
-                firstEpochFound = True
-                #print('first GPS Week and Seconds in the file', firstWeek, swk)
-            count += 1
-            if (wk != firstWeek):
-                #print('this is a problem - this code should not be used with files that crossover GPS weeks ')
-                #print('JAXA orbits have this extra point, which is going to be thrown out')
-                ignorePoint = True
-        if (line[0] == 'P') and (not ignorePoint):
+        if line[0] == 'P':
             co = line[1]
             if co == 'J':
                 continue  # skip QZSS; collides with BeiDou in findConstell

--- a/gnssrefl/nmea2snr.py
+++ b/gnssrefl/nmea2snr.py
@@ -9,7 +9,7 @@ import tempfile
 from scipy.interpolate import interp1d, CubicSpline
 
 import gnssrefl.gps as g
-from gnssrefl.snrfile_functions import constants, elev_limits as snr_elev_limits, propagate_and_azel_sp3
+from gnssrefl.snrfile_functions import constants, elev_limits as snr_elev_limits, propagate_and_azel_sp3, compute_continuous_seconds
 
 def nmea_apriori_coords(station,llh,sp3):
     """
@@ -417,17 +417,21 @@ def nmea_sp3_azel(recv, year, month, day, tod, prn, s1, s2, s5, s6, s7, s8,
     up, East, North = g.up(lat, lon)
 
     gweek0, gpssec0 = g.kgpsweek(year, month, day, 0, 0, 0)
-    obs_sow = gpssec0 + tod
 
     sp3 = g.read_sp3file(orbfile)
     if sp3.size == 0:
         print('SP3 file is empty or unreadable'); return
 
+    # orbits and observations share a timescale anchored to the first week in the sp3 file
+    week0 = sp3[0, 1]
+    sp3_t = compute_continuous_seconds(sp3[:, 1], sp3[:, 2], week0)
+    obs_t = compute_continuous_seconds(gweek0, gpssec0 + tod, week0)
+
     # pre-index SP3 data by satellite number
     sp3_index = {}
     for sat_id in np.unique(sp3[:, 0]).astype(int):
         m = sp3[:, 0] == sat_id
-        sp3_index[sat_id] = (sp3[m, 2], sp3[m, 3], sp3[m, 4], sp3[m, 5])
+        sp3_index[sat_id] = (sp3_t[m], sp3[m, 3], sp3[m, 4], sp3[m, 5])
 
     oE = constants.omegaEarth
     clight = constants.c
@@ -447,7 +451,7 @@ def nmea_sp3_azel(recv, year, month, day, tod, prn, s1, s2, s5, s6, s7, s8,
         iZ = CubicSpline(sp3_sec, z, extrapolate=True)
 
         mask = (prn == sat_id)
-        t_sat = obs_sow[mask]
+        t_sat = obs_t[mask]
         s1_sat = s1[mask]; s2_sat = s2[mask]; s5_sat = s5[mask]
         s6_sat = s6[mask]; s7_sat = s7[mask]; s8_sat = s8[mask]
         tod_sat = tod[mask]

--- a/gnssrefl/rinex2snr.py
+++ b/gnssrefl/rinex2snr.py
@@ -19,7 +19,7 @@ import gnssrefl.rinpy as rinpy
 import gnssrefl.karnak_libraries as k
 import gnssrefl.highrate as ch
 
-from gnssrefl.snrfile_functions import constants, elev_limits, propagate_and_azel_sp3
+from gnssrefl.snrfile_functions import constants, elev_limits, propagate_and_azel_sp3, compute_continuous_seconds
 
 #
 #
@@ -1020,11 +1020,16 @@ def write_snr_from_sp3(gpstime,sp3,systemsatlists,obsdata,obstypes,prntoidx,year
     # epoch at the beginning of the day of your RINEX file
     gweek0, gpssec0 = g.kgpsweek(year, month,day,0,0,0 )
 
+    # orbits and observations share a timescale anchored to the first week in the sp3 file
+    week0 = sp3[0, 1]
+    sp3_t = compute_continuous_seconds(sp3[:, 1], sp3[:, 2], week0)
+    tod0 = compute_continuous_seconds(gweek0, gpssec0, week0)
+
     # pre-index SP3 data by satellite number (avoids repeated boolean scans)
     sp3_index = {}
     for sat_id in np.unique(sp3[:, 0]).astype(int):
         m = sp3[:, 0] == sat_id
-        sp3_index[sat_id] = (sp3[m, 2], sp3[m, 3], sp3[m, 4], sp3[m, 5])  # sec, x, y, z
+        sp3_index[sat_id] = (sp3_t[m], sp3[m, 3], sp3[m, 4], sp3[m, 5])  # sec, x, y, z
 
     oE = constants.omegaEarth
     clight = constants.c
@@ -1066,7 +1071,8 @@ def write_snr_from_sp3(gpstime,sp3,systemsatlists,obsdata,obstypes,prntoidx,year
                         if skey in obslist:
                             all_nan = all_nan & np.isnan(obsdata[con][skey][:, prntoidx[con][prn]])
                     not_ij = ~all_nan
-                    Tp = gpstime[not_ij,1] # only use the seconds of the week for now
+                    sow = gpstime[not_ij,1]
+                    Tp = compute_continuous_seconds(gpstime[not_ij,0], sow, week0)
                     s1 = s1[not_ij]; is1 = np.isnan(s1); s1[is1] = 0
                     emp = np.zeros(len(s1),dtype=float)
         # get the rest of the SNR data in a function
@@ -1078,7 +1084,7 @@ def write_snr_from_sp3(gpstime,sp3,systemsatlists,obsdata,obstypes,prntoidx,year
 
                     # --- decimation filter (vectorized) ---
                     if checkD:
-                        dec_mask = (Tp % dec_rate) == 0
+                        dec_mask = (sow % dec_rate) == 0
                     else:
                         dec_mask = np.ones(nepochs, dtype=bool)
 
@@ -1104,7 +1110,7 @@ def write_snr_from_sp3(gpstime,sp3,systemsatlists,obsdata,obstypes,prntoidx,year
                     edot_all = 2.0 * (elv_after - eleA_all[elev_mask])
 
                     # --- accumulate as array block ---
-                    tod_pass = t_all[elev_mask] - gpssec0
+                    tod_pass = t_all[elev_mask] - tod0
                     idx_pass = idx_all[elev_mask]
                     n_pass = len(tod_pass)
                     block = np.empty((n_pass, 12))

--- a/gnssrefl/snrfile_functions.py
+++ b/gnssrefl/snrfile_functions.py
@@ -37,6 +37,29 @@ def elev_limits(snroption):
     return emin, emax
 
 
+def compute_continuous_seconds(week, sow, week0):
+    """
+    Puts GPS times on a single timescale anchored to the start of week0, so that
+    a GPS week rollover part way through a multi-day orbit file does not send the
+    seconds back to zero.
+
+    Parameters
+    ----------
+    week : int or ndarray
+        GPS week
+    sow : float or ndarray
+        seconds of the GPS week
+    week0 : int
+        GPS week the timescale is anchored to
+
+    Returns
+    -------
+    seconds : float or ndarray
+        seconds since the start of week0
+    """
+    return (week - week0)*604800.0 + sow
+
+
 def propagate_and_azel_sp3(iX, iY, iZ, t, recv, up, East, North, oE, clight):
     """
     Vectorized SP3 orbit propagation with light-time iteration, then azimuth/elevation.


### PR DESCRIPTION
This PR fixes an issue with ultra-rapid Wuhan orbits (#425) caused by a bug related to multi-day orbit files and the GPS week rollover.

This was an existing bug in the old python-hybrid translator and was then inherited in the transition to pure-python.

# Issue

`read_sp3file` can read multi-day orbit files, but currently discards any epochs after a GPS week rollover to avoid seconds-of-week resetting to zero.

This causes a problem for wum2 ultra-rapid orbits. To acquire an orbit for day N (which may not exist yet if day N is today), `get_wuhan_orbits` downloads the orbit file for day N-1. This file spans two days and should therefore also cover day N.

However, when day N is Sunday, the file crosses a GPS week boundary at midnight. `read_sp3file` discards the epochs from the new GPS week, leaving no orbit data for Sunday.

As a result, `rinex2snr -orb wum2` fails when processing Sundays.

# Fix

`read_sp3file `now retains all epochs in a multi-day orbit file. When the orbit data is used, both the SP3 epochs and observation epochs are converted from (GPS week, seconds-of-week) to a continuous seconds value anchored to the first GPS week in the SP3 file:

```
continuous_seconds = (week - week0) * 604800 + seconds_of_week
```